### PR TITLE
feat: Action Protocol backend (CRUD + mark-used with effectiveness log)

### DIFF
--- a/src/main/java/org/mentorship/reflectly/controller/ActionProtocolController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/ActionProtocolController.java
@@ -1,0 +1,159 @@
+package org.mentorship.reflectly.controller;
+
+import org.mentorship.reflectly.constants.ApiConstants;
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.MarkProtocolUsedRequestDto;
+import org.mentorship.reflectly.dto.PagedResponseDto;
+import org.mentorship.reflectly.security.GoogleAuthenticationToken;
+import org.mentorship.reflectly.service.ActionProtocolService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import java.net.URI;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springdoc.core.annotations.ParameterObject;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/protocols")
+@RequiredArgsConstructor
+public class ActionProtocolController {
+
+    private final ActionProtocolService actionProtocolService;
+
+    @Operation(summary = "Get action protocols", description = "Get all action protocols for the current user, paginated")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocols retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<ActionProtocolResponseDto>> getAllProtocols(
+            GoogleAuthenticationToken authentication,
+            @ParameterObject Pageable pageable) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        Page<ActionProtocolResponseDto> pageResult = actionProtocolService.getAllProtocols(userId, pageable);
+
+        String nextLink = null;
+        if (pageResult.hasNext()) {
+            nextLink = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .replaceQueryParam("page", pageResult.getNumber() + 1)
+                    .toUriString();
+        }
+
+        return ResponseEntity.ok(new PagedResponseDto<>(
+                pageResult.getContent(),
+                pageResult.getTotalElements(),
+                nextLink
+        ));
+    }
+
+    @Operation(summary = "Get action protocol by ID", description = "Get a specific action protocol by its ID for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<ActionProtocolResponseDto> getProtocolById(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.getProtocolById(userId, id);
+        return ResponseEntity.ok(protocol);
+    }
+
+    @Operation(summary = "Create action protocol", description = "Create a new action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.CREATED, description = "Action protocol created successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping
+    public ResponseEntity<ActionProtocolResponseDto> createProtocol(
+            @Valid @RequestBody ActionProtocolRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.createProtocol(userId, requestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(protocol.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(protocol);
+    }
+
+    @Operation(summary = "Update action protocol", description = "Update an existing action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol updated successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<ActionProtocolResponseDto> updateProtocol(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            @Valid @RequestBody ActionProtocolRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.updateProtocol(userId, id, requestDto);
+        return ResponseEntity.ok(protocol);
+    }
+
+    @Operation(summary = "Delete action protocol", description = "Delete an action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.NO_CONTENT, description = "Action protocol deleted successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProtocol(
+            @Parameter(description = "Action protocol ID") @PathVariable String id, GoogleAuthenticationToken authentication) {
+        String userId = getUserIdFromAuthentication(authentication);
+        actionProtocolService.deleteProtocol(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Mark action protocol as used", description = "Records a use of the protocol: increments its usage count, stamps lastUsedAt, and logs the effectiveness")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol usage recorded successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping("/{id}/use")
+    public ResponseEntity<ActionProtocolResponseDto> markUsed(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            @Valid @RequestBody MarkProtocolUsedRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.markUsed(userId, id, requestDto);
+        return ResponseEntity.ok(protocol);
+    }
+
+    private String getUserIdFromAuthentication(GoogleAuthenticationToken authentication) {
+        if (authentication != null && authentication.getUser() != null) {
+            return authentication.getUser().getId().toString();
+        }
+        throw new RuntimeException(ApiConstants.USER_NOT_AUTHENTICATED);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/converter/ActionProtocolConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/ActionProtocolConverter.java
@@ -1,0 +1,72 @@
+package org.mentorship.reflectly.converter;
+
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.ProtocolUsageResponseDto;
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActionProtocolConverter {
+
+    public ActionProtocolResponseDto toResponseDto(ActionProtocolEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return ActionProtocolResponseDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .title(entity.getTitle())
+                .trigger(entity.getTrigger())
+                .script(entity.getScript())
+                .usageCount(entity.getUsageCount())
+                .lastUsedAt(entity.getLastUsedAt())
+                .createdAt(entity.getCreatedDate())
+                .updatedAt(entity.getLastModifiedDate())
+                .build();
+    }
+
+    public ActionProtocolEntity toEntity(ActionProtocolRequestDto requestDto, String id, String userId) {
+        if (requestDto == null) {
+            return null;
+        }
+        return new ActionProtocolEntity(
+                id,
+                userId,
+                requestDto.getTitle(),
+                requestDto.getTrigger(),
+                requestDto.getScript()
+        );
+    }
+
+    public void updateEntityFromDto(ActionProtocolRequestDto requestDto, ActionProtocolEntity entity) {
+        if (requestDto == null || entity == null) {
+            return;
+        }
+        entity.setTitle(requestDto.getTitle());
+        entity.setTrigger(requestDto.getTrigger());
+        entity.setScript(requestDto.getScript());
+    }
+
+    public Page<ActionProtocolResponseDto> toResponseDtoPage(Page<ActionProtocolEntity> entityPage) {
+        if (entityPage == null) {
+            return null;
+        }
+        return entityPage.map(this::toResponseDto);
+    }
+
+    public ProtocolUsageResponseDto toUsageResponseDto(ProtocolUsageEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return ProtocolUsageResponseDto.builder()
+                .id(entity.getId())
+                .protocolId(entity.getProtocolId())
+                .effectiveness(entity.getEffectiveness())
+                .note(entity.getNote())
+                .usedAt(entity.getUsedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ActionProtocolRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ActionProtocolRequestDto.java
@@ -1,0 +1,25 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActionProtocolRequestDto {
+
+    @NotBlank(message = "Title is required")
+    @Size(max = 255, message = "Title must not exceed 255 characters")
+    private String title;
+
+    @NotBlank(message = "Trigger is required")
+    @Size(max = 255, message = "Trigger must not exceed 255 characters")
+    private String trigger;
+
+    @NotBlank(message = "Script is required")
+    @Size(max = 5000, message = "Script must not exceed 5000 characters")
+    private String script;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ActionProtocolResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ActionProtocolResponseDto.java
@@ -1,0 +1,25 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActionProtocolResponseDto {
+
+    private String id;
+    private String userId;
+    private String title;
+    private String trigger;
+    private String script;
+    private Integer usageCount;
+    private Instant lastUsedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/MarkProtocolUsedRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/MarkProtocolUsedRequestDto.java
@@ -1,0 +1,20 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.EffectivenessLevel;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkProtocolUsedRequestDto {
+
+    @NotNull(message = "Effectiveness is required")
+    private EffectivenessLevel effectiveness;
+
+    @Size(max = 500, message = "Note must not exceed 500 characters")
+    private String note;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ProtocolUsageResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ProtocolUsageResponseDto.java
@@ -1,0 +1,22 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.EffectivenessLevel;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProtocolUsageResponseDto {
+
+    private String id;
+    private String protocolId;
+    private EffectivenessLevel effectiveness;
+    private String note;
+    private Instant usedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/model/ActionProtocolEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/ActionProtocolEntity.java
@@ -1,0 +1,61 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A user-authored coping script ("Action Protocol") tied to a trigger/situation.
+ * The user writes it in advance and, in the moment, follows it and marks it used
+ * with a short effectiveness rating so the script can be refined over time.
+ */
+@Entity
+@Table(name = "action_protocols", indexes = {
+        @Index(name = "idx_actionprotocol_user", columnList = "userId")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActionProtocolEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "trigger_situation", nullable = false, length = 255)
+    private String trigger;
+
+    @Column(name = "script", nullable = false, columnDefinition = "TEXT")
+    private String script;
+
+    @Column(name = "usage_count", nullable = false)
+    private Integer usageCount = 0;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    public ActionProtocolEntity(String id, String userId, String title, String trigger, String script) {
+        this.id = Objects.requireNonNull(id, "ID cannot be null");
+        this.userId = Objects.requireNonNull(userId, "User ID cannot be null");
+        this.title = Objects.requireNonNull(title, "Title cannot be null");
+        this.trigger = Objects.requireNonNull(trigger, "Trigger cannot be null");
+        this.script = Objects.requireNonNull(script, "Script cannot be null");
+        this.usageCount = 0;
+    }
+
+    /** Records a single use: bumps the counter and stamps the timestamp. */
+    public void recordUsage(Instant usedAt) {
+        this.usageCount = (this.usageCount == null ? 0 : this.usageCount) + 1;
+        this.lastUsedAt = usedAt != null ? usedAt : Instant.now();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/model/EffectivenessLevel.java
+++ b/src/main/java/org/mentorship/reflectly/model/EffectivenessLevel.java
@@ -1,0 +1,10 @@
+package org.mentorship.reflectly.model;
+
+/**
+ * Self-reported effectiveness of a coping protocol after a single use.
+ */
+public enum EffectivenessLevel {
+    WORKED,
+    PARTIAL,
+    DIDNT_WORK
+}

--- a/src/main/java/org/mentorship/reflectly/model/ProtocolUsageEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/ProtocolUsageEntity.java
@@ -1,0 +1,54 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A single logged use of an {@link ActionProtocolEntity}: when it was used and how
+ * effective it was. Kept as its own append-only log so effectiveness-over-time can be
+ * charted in a later phase without losing history.
+ */
+@Entity
+@Table(name = "protocol_usages", indexes = {
+        @Index(name = "idx_protocolusage_protocol", columnList = "protocolId"),
+        @Index(name = "idx_protocolusage_user", columnList = "userId")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProtocolUsageEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "protocol_id", nullable = false, length = 36)
+    private String protocolId;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "effectiveness", nullable = false, length = 20)
+    private EffectivenessLevel effectiveness;
+
+    @Column(name = "note", length = 500)
+    private String note;
+
+    @Column(name = "used_at", nullable = false)
+    private Instant usedAt;
+
+    public ProtocolUsageEntity(String id, String protocolId, String userId, EffectivenessLevel effectiveness, String note, Instant usedAt) {
+        this.id = Objects.requireNonNull(id, "ID cannot be null");
+        this.protocolId = Objects.requireNonNull(protocolId, "Protocol ID cannot be null");
+        this.userId = Objects.requireNonNull(userId, "User ID cannot be null");
+        this.effectiveness = Objects.requireNonNull(effectiveness, "Effectiveness cannot be null");
+        this.note = note;
+        this.usedAt = usedAt != null ? usedAt : Instant.now();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/repository/ActionProtocolRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/ActionProtocolRepository.java
@@ -1,0 +1,28 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ActionProtocolRepository extends JpaRepository<ActionProtocolEntity, String> {
+
+    /**
+     * Find all action protocols by user ID with pagination, most recently created first.
+     */
+    Page<ActionProtocolEntity> findByUserIdOrderByCreatedDateDesc(String userId, Pageable pageable);
+
+    /**
+     * Find an action protocol by ID and user ID (for security - users can only access their own protocols).
+     */
+    Optional<ActionProtocolEntity> findByIdAndUserId(String id, String userId);
+
+    /**
+     * Check if an action protocol exists and belongs to a specific user.
+     */
+    boolean existsByIdAndUserId(String id, String userId);
+}

--- a/src/main/java/org/mentorship/reflectly/repository/ProtocolUsageRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/ProtocolUsageRepository.java
@@ -1,0 +1,17 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProtocolUsageRepository extends JpaRepository<ProtocolUsageEntity, String> {
+
+    /**
+     * Find all usage log entries for a protocol, most recent first.
+     * Reserved for a future "effectiveness over time" view.
+     */
+    List<ProtocolUsageEntity> findByProtocolIdAndUserIdOrderByUsedAtDesc(String protocolId, String userId);
+}

--- a/src/main/java/org/mentorship/reflectly/service/ActionProtocolService.java
+++ b/src/main/java/org/mentorship/reflectly/service/ActionProtocolService.java
@@ -1,0 +1,106 @@
+package org.mentorship.reflectly.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.mentorship.reflectly.converter.ActionProtocolConverter;
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.MarkProtocolUsedRequestDto;
+import org.mentorship.reflectly.exception.NotFoundException;
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.mentorship.reflectly.repository.ActionProtocolRepository;
+import org.mentorship.reflectly.repository.ProtocolUsageRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Validated
+public class ActionProtocolService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ActionProtocolRepository actionProtocolRepository;
+    private final ProtocolUsageRepository protocolUsageRepository;
+    private final ActionProtocolConverter actionProtocolConverter;
+
+    @Transactional(readOnly = true)
+    public Page<ActionProtocolResponseDto> getAllProtocols(String userId, Pageable pageable) {
+        Pageable validatedPageable = validateAndCreatePageable(pageable);
+        Page<ActionProtocolEntity> protocolPage = actionProtocolRepository.findByUserIdOrderByCreatedDateDesc(userId, validatedPageable);
+        return actionProtocolConverter.toResponseDtoPage(protocolPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ActionProtocolResponseDto getProtocolById(String userId, String protocolId) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+        return actionProtocolConverter.toResponseDto(protocol);
+    }
+
+    public ActionProtocolResponseDto createProtocol(String userId, ActionProtocolRequestDto requestDto) {
+        String protocolId = UUID.randomUUID().toString();
+        ActionProtocolEntity protocol = actionProtocolConverter.toEntity(requestDto, protocolId, userId);
+
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    public ActionProtocolResponseDto updateProtocol(String userId, String protocolId, ActionProtocolRequestDto requestDto) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+
+        actionProtocolConverter.updateEntityFromDto(requestDto, protocol);
+
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    public void deleteProtocol(String userId, String protocolId) {
+        if (!actionProtocolRepository.existsByIdAndUserId(protocolId, userId)) {
+            throw new NotFoundException("Action protocol not found");
+        }
+
+        actionProtocolRepository.deleteById(protocolId);
+    }
+
+    /**
+     * Marks a protocol as used: increments its usage counter, stamps lastUsedAt, and
+     * appends an entry to the usage log so effectiveness can be tracked over time.
+     */
+    public ActionProtocolResponseDto markUsed(String userId, String protocolId, MarkProtocolUsedRequestDto requestDto) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+
+        Instant usedAt = Instant.now();
+        protocol.recordUsage(usedAt);
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+
+        ProtocolUsageEntity usage = new ProtocolUsageEntity(
+                UUID.randomUUID().toString(),
+                protocolId,
+                userId,
+                requestDto.getEffectiveness(),
+                requestDto.getNote(),
+                usedAt
+        );
+        protocolUsageRepository.save(usage);
+
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    private Pageable validateAndCreatePageable(Pageable pageable) {
+        int page = Math.max(0, pageable.getPageNumber());
+        int pageSize = Math.min(Math.max(1, pageable.getPageSize()), MAX_PAGE_SIZE);
+        return PageRequest.of(page, pageSize, pageable.getSort());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ActionProtocolEntity` (title/trigger/script/usageCount/lastUsedAt) + a child `ProtocolUsageEntity` append-only usage log (effectiveness enum + optional note) so effectiveness-over-time can be charted in a later phase without losing history.
- Mirrors the Energy Tracking vertical: repository/service/converter/controller under `/api/protocols`, ownership-scoped via `findByIdAndUserId`/`existsByIdAndUserId`, paginated list via `PagedResponseDto`.
- `POST /api/protocols/{id}/use` records a use (bumps `usageCount`, stamps `lastUsedAt`, logs effectiveness) and returns the updated protocol.
- Paired with FE PR `hankimthuy/reflectly-fe#77` (already merged).

## Test plan
- [x] `./mvnw.cmd clean compile` — clean
- [x] Endpoints mirror the already-verified Energy Tracking pattern (auth via `GoogleAuthenticationToken`, `ValidationException`/`NotFoundException` handled centrally)
- [ ] Manual Swagger/JWT smoke test against the merged `integration/phase-1` — will run as part of end-to-end verification after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)