### PR TITLE
Phase 1b: Entry Templates + Action Protocol + Dashboard (BE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ build/
 
 ### Environment Variables ###
 .env
+
+### Local runtime logs & agent scratch ###
+be_*.log
+*_err.log
+*_stderr*.log
+*_stdout*.log
+.claude/

--- a/documentation/00-Product-Context/Feature-System-Roadmap.md
+++ b/documentation/00-Product-Context/Feature-System-Roadmap.md
@@ -1,0 +1,96 @@
+# MimoSe — Hệ thống tính năng & Lộ trình phát hành
+
+> Tài liệu này tổng hợp toàn bộ mặt bằng tính năng mà MimoSe có thể cung cấp, sắp xếp theo lớp kiến trúc sản phẩm (dựa trên 3 trụ cột đã định nghĩa trong PRD: Innerverse – Outerverse – Bridge), và đề xuất lộ trình release theo phase để có bản MVP dùng được sớm, sau đó bổ sung dần.
+
+## 1. Nguyên tắc chọn & sắp xếp tính năng
+
+- **Đồng hành, không lý thuyết**: mỗi tính năng phải gắn với một hành động cụ thể user có thể làm ngay, không phải nội dung để đọc.
+- **Tự giải quyết**: app đưa công cụ/khung hỏi, không đưa lời khuyên thay user.
+- **Protocol có vòng đời**: cách giải quyết không phải "làm 1 lần xong", cần theo dõi hiệu quả theo thời gian và báo khi cần điều chỉnh.
+- **Tiện lợi tại đúng khoảnh khắc**: ưu tiên thao tác nhanh (1-2 chạm) hơn là form dài, đặc biệt với các tính năng dùng lúc đang stress.
+
+## 2. Kiến trúc tính năng theo lớp
+
+### Layer 0 — Nền tảng (đã có)
+Auth (Google OAuth + username/password), User profile, Journal Entries (CRUD tự do).
+
+### Layer 1 — Innerverse (Nội tâm)
+| Tính năng | Mô tả |
+|---|---|
+| Energy tracking nhanh | Log năng lượng 1-chạm (thang điểm), gắn context tag (công việc, xã hội, nghỉ ngơi...) |
+| Core values | User tự định nghĩa 3-5 giá trị cốt lõi, dùng làm bộ lọc khi ra quyết định |
+| Emotion/mood tagging | Gắn cảm xúc cụ thể vào entry/energy log thay vì chỉ số chung chung |
+| Biểu đồ xu hướng | Trực quan hóa năng lượng theo thời gian và theo context tag |
+
+### Layer 2 — Outerverse (Ngoại giới)
+| Tính năng | Mô tả |
+|---|---|
+| Danh bạ mối quan hệ | Thêm người quan trọng trong đời sống user |
+| Orbit system | Phân loại độ gần (1-5) theo tần suất tương tác + xếp hạng chủ quan |
+| Impact assessment | Đo mối quan hệ này ảnh hưởng năng lượng user thế nào theo thời gian |
+| Nhật ký tương tác | Ghi lại các tương tác đáng chú ý với từng người |
+
+### Layer 3 — Bridge (Cầu nối hành động) — lõi USP
+| Tính năng | Mô tả |
+|---|---|
+| Action Protocol | Kịch bản ứng phó do user tự viết hoặc chọn từ mẫu, gắn theo tình huống/trigger cụ thể |
+| Script templates | Mẫu câu, kịch bản giao tiếp cho tình huống khó (seed ban đầu từ chính trải nghiệm của bạn) |
+| Protocol effectiveness tracking | Mỗi lần áp dụng protocol, ghi nhận kết quả; hệ thống phát hiện xu hướng giảm hiệu quả theo thời gian |
+| Pattern recognition | Liên kết dữ liệu Inner (năng lượng) – Outer (orbit) – Bridge (protocol) để gợi ý đúng lúc |
+
+### Layer 4 — Companion (Đồng hành chủ động)
+| Tính năng | Mô tả |
+|---|---|
+| Smart nudge | Thông báo đúng lúc dựa trên pattern phát hiện được (không phải nhắc chung chung) |
+| Memory resurfacing | Nhắc lại entry/protocol cũ liên quan khi user gặp tình huống tương tự |
+| "Đọc lại hiện tại" | Tổng hợp khách quan pattern gần đây, trình bày lại cho user tự nhận ra thay vì app kết luận thay |
+| Check-in định kỳ | Tự-audit định kỳ (theo tuần/tháng/quý) |
+
+### Layer 5 — Insight & Growth
+Dashboard thống kê tổng hợp, quotes/nội dung cá nhân hóa theo pattern, growth timeline/milestones.
+
+### Layer 6 — Mở rộng dài hạn (tùy chọn, cân nhắc kỹ)
+AI-assisted reflection/summarization, chia sẻ protocol ẩn danh giữa cộng đồng có hoàn cảnh tương tự, tích hợp chuyên gia tham vấn, tích hợp wearable/calendar.
+
+## 3. Lộ trình theo Phase
+
+### Phase 1 — MVP dùng được ngay
+**Mục tiêu:** tạo vòng lặp giá trị tối thiểu — ghi nhận → phản chiếu → protocol cá nhân — không cần Outerverse hay AI.
+
+- Giữ nguyên Layer 0 đã có (Auth, Profile, Entries).
+- Energy tracking cơ bản (1-chạm + context tag) — nền cho mọi phân tích sau này.
+- Entry templates theo 2-3 chủ đề bạn có trải nghiệm sâu nhất (thay trang trắng bằng câu hỏi dẫn dắt).
+- Action Protocol cơ bản: tạo/sửa/đánh dấu "đã dùng" + ghi kết quả ngắn (hiệu quả/không).
+- Dashboard đơn giản: biểu đồ năng lượng theo thời gian.
+
+*Vì sao dừng ở đây:* đây là bộ tối thiểu để user thấy giá trị thật (không chỉ viết mà còn có nơi lưu & tái sử dụng cách giải quyết), đồng thời bắt đầu tích lũy dữ liệu cần cho Phase 2.
+
+### Phase 2 — Đồng hành chủ động
+Cần dữ liệu tích lũy từ Phase 1 để cá nhân hóa được.
+
+- Outerverse: danh bạ, orbit system, impact assessment.
+- Protocol effectiveness tracking đầy đủ (log mỗi lần dùng, phát hiện xu hướng giảm hiệu quả).
+- Smart nudge dựa trên pattern thực tế đã có.
+- Memory resurfacing (gợi lại entry/protocol cũ liên quan).
+
+### Phase 3 — Insight sâu
+- "Đọc lại hiện tại" — gương phản chiếu định kỳ, tổng hợp Inner + Outer + Bridge.
+- Pattern recognition nâng cao liên kết 3 lớp.
+- Cá nhân hóa nội dung/quotes theo pattern thực tế của từng user.
+
+### Phase 4 — Tăng trưởng & cộng đồng (dài hạn, cân nhắc theo nhu cầu thị trường)
+- Chia sẻ protocol ẩn danh giữa các user có hoàn cảnh tương tự.
+- Tích hợp chuyên gia/coach khi pattern cho thấy cần hỗ trợ chuyên sâu hơn app tự làm được.
+- AI-assisted summarization, tích hợp wearable/calendar.
+
+## 4. Điều kiện chuyển phase (gợi ý)
+
+- **Phase 1 → 2**: user tạo được trung bình ≥2-3 protocol/tháng và quay lại dùng entry template đều đặn — cho thấy vòng lặp Layer 1+3 có giá trị thật, đủ nền để mở rộng sang Outerverse.
+- **Phase 2 → 3**: có đủ dữ liệu lịch sử (ví dụ ≥3 tháng liên tục) để pattern recognition cho ra gợi ý có ý nghĩa, không phải suy diễn từ dữ liệu quá ít.
+- **Phase 3 → 4**: đã có tệp user gắn bó ổn định, nhu cầu vượt ngoài khả năng tự-giải-quyết bắt đầu xuất hiện rõ (feedback yêu cầu kết nối chuyên gia/cộng đồng).
+
+## 5. Rủi ro & giả định cần validate trước khi build sâu
+
+- Giả định "user sẽ log năng lượng đều đặn" cần test bằng bản thử nghiệm nhỏ trước khi đầu tư nhiều vào phân tích pattern.
+- Giả định "protocol tự viết sẽ hữu ích hơn nội dung có sẵn" nên được kiểm chứng qua phỏng vấn 5-10 user mục tiêu trước Phase 1.
+- Tính năng "đọc lại hiện tại" cần cẩn trọng về ranh giới không đưa lời khuyên tâm lý — nên tham khảo ý kiến chuyên môn tâm lý khi thiết kế ngôn ngữ hiển thị.

--- a/documentation/migrations/001-add-entry-template-key.sql
+++ b/documentation/migrations/001-add-entry-template-key.sql
@@ -1,0 +1,6 @@
+-- 001 — Entry Templates: track which guided template an entry was written with.
+-- Additive, nullable, online-safe on PostgreSQL. Existing rows keep template_key = NULL.
+-- Run against the production DB BEFORE deploying the jar that adds EntryEntity.templateKey
+-- (prod runs ddl-auto: validate and will fail boot otherwise).
+
+ALTER TABLE entries ADD COLUMN IF NOT EXISTS template_key varchar(50);

--- a/documentation/migrations/README.md
+++ b/documentation/migrations/README.md
@@ -1,0 +1,24 @@
+# Manual DB migrations (interim, pre-Flyway)
+
+This project has **no migration tool yet**. Locally, Hibernate `ddl-auto: update`
+(see `application.yml` / `application-local.yml`) auto-applies additive schema
+changes on boot, so nothing needs to be run by hand on a dev machine.
+
+**Production uses `ddl-auto: validate`** (`application-prod.yml`): the app will
+**fail to boot** if an entity references a column the database does not have.
+Therefore, for every schema change, the SQL in this folder must be run against
+the production database **before** deploying the jar that introduces it.
+
+All statements here are additive and online-safe on PostgreSQL (nullable column
+adds, new tables) — old rows remain valid.
+
+## Follow-up
+Adopt Flyway with a baseline migration as a dedicated task **before the next
+schema change**. Several features (Energy, Entry Templates, Action Protocol,
+Dashboard) are growing the schema with no migration history; hand-running ALTERs
+against prod is a stopgap, not the plan.
+
+## Ordered statements
+| # | File | Introduced by | Notes |
+|---|------|---------------|-------|
+| 001 | `001-add-entry-template-key.sql` | Entry Templates | Nullable column on `entries` |

--- a/src/main/java/org/mentorship/reflectly/config/AuditorAwareConfig.java
+++ b/src/main/java/org/mentorship/reflectly/config/AuditorAwareConfig.java
@@ -19,6 +19,6 @@ public class AuditorAwareConfig implements AuditorAware<String> {
         if (authentication == null || !authentication.isAuthenticated()) {
             return Optional.of("admin");
         }
-        return Optional.of(authentication.getName()); 
+        return Optional.ofNullable(authentication.getName()).or(() -> Optional.of("admin"));
     }
 }

--- a/src/main/java/org/mentorship/reflectly/controller/ActionProtocolController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/ActionProtocolController.java
@@ -1,0 +1,159 @@
+package org.mentorship.reflectly.controller;
+
+import org.mentorship.reflectly.constants.ApiConstants;
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.MarkProtocolUsedRequestDto;
+import org.mentorship.reflectly.dto.PagedResponseDto;
+import org.mentorship.reflectly.security.GoogleAuthenticationToken;
+import org.mentorship.reflectly.service.ActionProtocolService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import java.net.URI;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springdoc.core.annotations.ParameterObject;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/protocols")
+@RequiredArgsConstructor
+public class ActionProtocolController {
+
+    private final ActionProtocolService actionProtocolService;
+
+    @Operation(summary = "Get action protocols", description = "Get all action protocols for the current user, paginated")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocols retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<ActionProtocolResponseDto>> getAllProtocols(
+            GoogleAuthenticationToken authentication,
+            @ParameterObject Pageable pageable) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        Page<ActionProtocolResponseDto> pageResult = actionProtocolService.getAllProtocols(userId, pageable);
+
+        String nextLink = null;
+        if (pageResult.hasNext()) {
+            nextLink = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .replaceQueryParam("page", pageResult.getNumber() + 1)
+                    .toUriString();
+        }
+
+        return ResponseEntity.ok(new PagedResponseDto<>(
+                pageResult.getContent(),
+                pageResult.getTotalElements(),
+                nextLink
+        ));
+    }
+
+    @Operation(summary = "Get action protocol by ID", description = "Get a specific action protocol by its ID for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<ActionProtocolResponseDto> getProtocolById(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.getProtocolById(userId, id);
+        return ResponseEntity.ok(protocol);
+    }
+
+    @Operation(summary = "Create action protocol", description = "Create a new action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.CREATED, description = "Action protocol created successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping
+    public ResponseEntity<ActionProtocolResponseDto> createProtocol(
+            @Valid @RequestBody ActionProtocolRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.createProtocol(userId, requestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(protocol.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(protocol);
+    }
+
+    @Operation(summary = "Update action protocol", description = "Update an existing action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol updated successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<ActionProtocolResponseDto> updateProtocol(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            @Valid @RequestBody ActionProtocolRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.updateProtocol(userId, id, requestDto);
+        return ResponseEntity.ok(protocol);
+    }
+
+    @Operation(summary = "Delete action protocol", description = "Delete an action protocol for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.NO_CONTENT, description = "Action protocol deleted successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProtocol(
+            @Parameter(description = "Action protocol ID") @PathVariable String id, GoogleAuthenticationToken authentication) {
+        String userId = getUserIdFromAuthentication(authentication);
+        actionProtocolService.deleteProtocol(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Mark action protocol as used", description = "Records a use of the protocol: increments its usage count, stamps lastUsedAt, and logs the effectiveness")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Action protocol usage recorded successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Action protocol not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping("/{id}/use")
+    public ResponseEntity<ActionProtocolResponseDto> markUsed(
+            @Parameter(description = "Action protocol ID") @PathVariable String id,
+            @Valid @RequestBody MarkProtocolUsedRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        ActionProtocolResponseDto protocol = actionProtocolService.markUsed(userId, id, requestDto);
+        return ResponseEntity.ok(protocol);
+    }
+
+    private String getUserIdFromAuthentication(GoogleAuthenticationToken authentication) {
+        if (authentication != null && authentication.getUser() != null) {
+            return authentication.getUser().getId().toString();
+        }
+        throw new RuntimeException(ApiConstants.USER_NOT_AUTHENTICATED);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/controller/EnergyLogController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/EnergyLogController.java
@@ -1,0 +1,107 @@
+package org.mentorship.reflectly.controller;
+
+import org.mentorship.reflectly.constants.ApiConstants;
+import org.mentorship.reflectly.dto.EnergyLogRequestDto;
+import org.mentorship.reflectly.dto.EnergyLogResponseDto;
+import org.mentorship.reflectly.dto.PagedResponseDto;
+import org.mentorship.reflectly.security.GoogleAuthenticationToken;
+import org.mentorship.reflectly.service.EnergyLogService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import java.net.URI;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springdoc.core.annotations.ParameterObject;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/energy-logs")
+@RequiredArgsConstructor
+public class EnergyLogController {
+
+    private final EnergyLogService energyLogService;
+
+    @Operation(summary = "Get energy logs", description = "Get all energy logs for the current user, optionally filtered by context tag")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Energy logs retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<EnergyLogResponseDto>> getAllLogs(
+            @Parameter(description = "Filter by context tag") @RequestParam(required = false) String contextTag,
+            GoogleAuthenticationToken authentication,
+            @ParameterObject Pageable pageable) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        Page<EnergyLogResponseDto> pageResult = energyLogService.getAllLogs(userId, contextTag, pageable);
+
+        String nextLink = null;
+        if (pageResult.hasNext()) {
+            nextLink = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .replaceQueryParam("page", pageResult.getNumber() + 1)
+                    .toUriString();
+        }
+
+        return ResponseEntity.ok(new PagedResponseDto<>(
+                pageResult.getContent(),
+                pageResult.getTotalElements(),
+                nextLink
+        ));
+    }
+
+    @Operation(summary = "Log energy level", description = "Create a new energy log entry for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.CREATED, description = "Energy log created successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping
+    public ResponseEntity<EnergyLogResponseDto> createLog(
+            @Valid @RequestBody EnergyLogRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        EnergyLogResponseDto log = energyLogService.createLog(userId, requestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(log.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(log);
+    }
+
+    @Operation(summary = "Delete energy log", description = "Delete an energy log for the current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.NO_CONTENT, description = "Energy log deleted successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Energy log not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteLog(
+            @Parameter(description = "Energy log ID") @PathVariable String id, GoogleAuthenticationToken authentication) {
+        String userId = getUserIdFromAuthentication(authentication);
+        energyLogService.deleteLog(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private String getUserIdFromAuthentication(GoogleAuthenticationToken authentication) {
+        if (authentication != null && authentication.getUser() != null) {
+            return authentication.getUser().getId().toString();
+        }
+        throw new RuntimeException(ApiConstants.USER_NOT_AUTHENTICATED);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/controller/EnergyLogController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/EnergyLogController.java
@@ -9,6 +9,8 @@ import org.mentorship.reflectly.service.EnergyLogService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 
@@ -62,6 +64,20 @@ public class EnergyLogController {
                 pageResult.getTotalElements(),
                 nextLink
         ));
+    }
+
+    @Operation(summary = "Get energy logs in range", description = "Get raw energy-log points for the last N days (default 30), oldest first, for dashboard trend aggregation")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Energy logs retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping("/range")
+    public ResponseEntity<List<EnergyLogResponseDto>> getLogsInRange(
+            @Parameter(description = "Number of days back from now (default 30, max 366)") @RequestParam(required = false) Integer days,
+            GoogleAuthenticationToken authentication) {
+
+        String userId = getUserIdFromAuthentication(authentication);
+        return ResponseEntity.ok(energyLogService.getLogsInRange(userId, days));
     }
 
     @Operation(summary = "Log energy level", description = "Create a new energy log entry for the current user")

--- a/src/main/java/org/mentorship/reflectly/converter/ActionProtocolConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/ActionProtocolConverter.java
@@ -1,0 +1,72 @@
+package org.mentorship.reflectly.converter;
+
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.ProtocolUsageResponseDto;
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActionProtocolConverter {
+
+    public ActionProtocolResponseDto toResponseDto(ActionProtocolEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return ActionProtocolResponseDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .title(entity.getTitle())
+                .trigger(entity.getTrigger())
+                .script(entity.getScript())
+                .usageCount(entity.getUsageCount())
+                .lastUsedAt(entity.getLastUsedAt())
+                .createdAt(entity.getCreatedDate())
+                .updatedAt(entity.getLastModifiedDate())
+                .build();
+    }
+
+    public ActionProtocolEntity toEntity(ActionProtocolRequestDto requestDto, String id, String userId) {
+        if (requestDto == null) {
+            return null;
+        }
+        return new ActionProtocolEntity(
+                id,
+                userId,
+                requestDto.getTitle(),
+                requestDto.getTrigger(),
+                requestDto.getScript()
+        );
+    }
+
+    public void updateEntityFromDto(ActionProtocolRequestDto requestDto, ActionProtocolEntity entity) {
+        if (requestDto == null || entity == null) {
+            return;
+        }
+        entity.setTitle(requestDto.getTitle());
+        entity.setTrigger(requestDto.getTrigger());
+        entity.setScript(requestDto.getScript());
+    }
+
+    public Page<ActionProtocolResponseDto> toResponseDtoPage(Page<ActionProtocolEntity> entityPage) {
+        if (entityPage == null) {
+            return null;
+        }
+        return entityPage.map(this::toResponseDto);
+    }
+
+    public ProtocolUsageResponseDto toUsageResponseDto(ProtocolUsageEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return ProtocolUsageResponseDto.builder()
+                .id(entity.getId())
+                .protocolId(entity.getProtocolId())
+                .effectiveness(entity.getEffectiveness())
+                .note(entity.getNote())
+                .usedAt(entity.getUsedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/converter/EnergyLogConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/EnergyLogConverter.java
@@ -1,0 +1,47 @@
+package org.mentorship.reflectly.converter;
+
+import org.mentorship.reflectly.dto.EnergyLogRequestDto;
+import org.mentorship.reflectly.dto.EnergyLogResponseDto;
+import org.mentorship.reflectly.model.EnergyLogEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnergyLogConverter {
+
+    public EnergyLogResponseDto toResponseDto(EnergyLogEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return EnergyLogResponseDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .level(entity.getLevel())
+                .contextTag(entity.getContextTag())
+                .notes(entity.getNotes())
+                .loggedAt(entity.getLoggedAt())
+                .createdAt(entity.getCreatedDate())
+                .build();
+    }
+
+    public EnergyLogEntity toEntity(EnergyLogRequestDto requestDto, String id, String userId) {
+        if (requestDto == null) {
+            return null;
+        }
+        return new EnergyLogEntity(
+                id,
+                userId,
+                requestDto.getLevel(),
+                requestDto.getContextTag(),
+                requestDto.getNotes(),
+                requestDto.getLoggedAt()
+        );
+    }
+
+    public Page<EnergyLogResponseDto> toResponseDtoPage(Page<EnergyLogEntity> entityPage) {
+        if (entityPage == null) {
+            return null;
+        }
+        return entityPage.map(this::toResponseDto);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/converter/EntryConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/EntryConverter.java
@@ -22,6 +22,7 @@ public class EntryConverter {
                 .title(entity.getTitle())
                 .reflection(entity.getReflection())
                 .emotions(entity.getEmotions())
+                .templateKey(entity.getTemplateKey())
                 .createdAt(entity.getCreatedDate())
                 .updatedAt(entity.getLastModifiedDate())
                 .build();
@@ -31,13 +32,15 @@ public class EntryConverter {
         if (requestDto == null) {
             return null;
         }
-        return new EntryEntity(
+        EntryEntity entity = new EntryEntity(
                 id,
                 userId,
                 requestDto.getTitle(),
                 requestDto.getReflection(),
                 requestDto.getEmotions()
         );
+        entity.setTemplateKey(requestDto.getTemplateKey());
+        return entity;
     }
 
     public List<EntryResponseDto> toResponseDtoList(List<EntryEntity> entities) {
@@ -63,6 +66,7 @@ public class EntryConverter {
         entity.setTitle(requestDto.getTitle());
         entity.setReflection(requestDto.getReflection());
         entity.setEmotions(requestDto.getEmotions());
+        entity.setTemplateKey(requestDto.getTemplateKey());
     }
 }
 

--- a/src/main/java/org/mentorship/reflectly/dto/ActionProtocolRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ActionProtocolRequestDto.java
@@ -1,0 +1,25 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActionProtocolRequestDto {
+
+    @NotBlank(message = "Title is required")
+    @Size(max = 255, message = "Title must not exceed 255 characters")
+    private String title;
+
+    @NotBlank(message = "Trigger is required")
+    @Size(max = 255, message = "Trigger must not exceed 255 characters")
+    private String trigger;
+
+    @NotBlank(message = "Script is required")
+    @Size(max = 5000, message = "Script must not exceed 5000 characters")
+    private String script;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ActionProtocolResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ActionProtocolResponseDto.java
@@ -1,0 +1,25 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActionProtocolResponseDto {
+
+    private String id;
+    private String userId;
+    private String title;
+    private String trigger;
+    private String script;
+    private Integer usageCount;
+    private Instant lastUsedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/EnergyLogRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/EnergyLogRequestDto.java
@@ -1,0 +1,32 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EnergyLogRequestDto {
+
+    @NotNull(message = "Level is required")
+    @Min(value = 1, message = "Level must be between 1 and 10")
+    @Max(value = 10, message = "Level must be between 1 and 10")
+    private Integer level;
+
+    @NotBlank(message = "Context tag is required")
+    @Size(max = 50, message = "Context tag must not exceed 50 characters")
+    private String contextTag;
+
+    @Size(max = 1000, message = "Notes must not exceed 1000 characters")
+    private String notes;
+
+    private Instant loggedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/EnergyLogResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/EnergyLogResponseDto.java
@@ -1,0 +1,23 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EnergyLogResponseDto {
+
+    private String id;
+    private String userId;
+    private Integer level;
+    private String contextTag;
+    private String notes;
+    private Instant loggedAt;
+    private Instant createdAt;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/EntryRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/EntryRequestDto.java
@@ -24,4 +24,7 @@ public class EntryRequestDto {
 
     @NotEmpty(message = "At least one emotion is required")
     private List<String> emotions;
+
+    @Size(max = 50, message = "Template key must not exceed 50 characters")
+    private String templateKey;
 }

--- a/src/main/java/org/mentorship/reflectly/dto/EntryResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/EntryResponseDto.java
@@ -19,6 +19,7 @@ public class EntryResponseDto {
     private String title;
     private String reflection;
     private List<String> emotions;
+    private String templateKey;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/org/mentorship/reflectly/dto/MarkProtocolUsedRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/MarkProtocolUsedRequestDto.java
@@ -1,0 +1,20 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.EffectivenessLevel;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkProtocolUsedRequestDto {
+
+    @NotNull(message = "Effectiveness is required")
+    private EffectivenessLevel effectiveness;
+
+    @Size(max = 500, message = "Note must not exceed 500 characters")
+    private String note;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ProtocolUsageResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ProtocolUsageResponseDto.java
@@ -1,0 +1,22 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.EffectivenessLevel;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProtocolUsageResponseDto {
+
+    private String id;
+    private String protocolId;
+    private EffectivenessLevel effectiveness;
+    private String note;
+    private Instant usedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/model/ActionProtocolEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/ActionProtocolEntity.java
@@ -1,0 +1,61 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A user-authored coping script ("Action Protocol") tied to a trigger/situation.
+ * The user writes it in advance and, in the moment, follows it and marks it used
+ * with a short effectiveness rating so the script can be refined over time.
+ */
+@Entity
+@Table(name = "action_protocols", indexes = {
+        @Index(name = "idx_actionprotocol_user", columnList = "userId")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActionProtocolEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "trigger_situation", nullable = false, length = 255)
+    private String trigger;
+
+    @Column(name = "script", nullable = false, columnDefinition = "TEXT")
+    private String script;
+
+    @Column(name = "usage_count", nullable = false)
+    private Integer usageCount = 0;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    public ActionProtocolEntity(String id, String userId, String title, String trigger, String script) {
+        this.id = Objects.requireNonNull(id, "ID cannot be null");
+        this.userId = Objects.requireNonNull(userId, "User ID cannot be null");
+        this.title = Objects.requireNonNull(title, "Title cannot be null");
+        this.trigger = Objects.requireNonNull(trigger, "Trigger cannot be null");
+        this.script = Objects.requireNonNull(script, "Script cannot be null");
+        this.usageCount = 0;
+    }
+
+    /** Records a single use: bumps the counter and stamps the timestamp. */
+    public void recordUsage(Instant usedAt) {
+        this.usageCount = (this.usageCount == null ? 0 : this.usageCount) + 1;
+        this.lastUsedAt = usedAt != null ? usedAt : Instant.now();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/model/EffectivenessLevel.java
+++ b/src/main/java/org/mentorship/reflectly/model/EffectivenessLevel.java
@@ -1,0 +1,10 @@
+package org.mentorship.reflectly.model;
+
+/**
+ * Self-reported effectiveness of a coping protocol after a single use.
+ */
+public enum EffectivenessLevel {
+    WORKED,
+    PARTIAL,
+    DIDNT_WORK
+}

--- a/src/main/java/org/mentorship/reflectly/model/EnergyLogEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/EnergyLogEntity.java
@@ -1,0 +1,50 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Represents a single energy-level check-in (1-10 scale) tagged with a situational context.
+ */
+@Entity
+@Table(name = "energy_logs", indexes = {
+        @Index(name = "idx_energylog_user_loggedat", columnList = "userId, loggedAt")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EnergyLogEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "level", nullable = false)
+    private Integer level;
+
+    @Column(name = "context_tag", nullable = false, length = 50)
+    private String contextTag;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "logged_at", nullable = false)
+    private Instant loggedAt;
+
+    public EnergyLogEntity(String id, String userId, Integer level, String contextTag, String notes, Instant loggedAt) {
+        this.id = Objects.requireNonNull(id, "ID cannot be null");
+        this.userId = Objects.requireNonNull(userId, "User ID cannot be null");
+        this.level = Objects.requireNonNull(level, "Level cannot be null");
+        this.contextTag = Objects.requireNonNull(contextTag, "Context tag cannot be null");
+        this.notes = notes;
+        this.loggedAt = loggedAt != null ? loggedAt : Instant.now();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/model/EntryEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/EntryEntity.java
@@ -42,6 +42,10 @@ public class EntryEntity extends AuditableEntity {
     @Column(name = "emotion", length = 50)
     private List<String> emotions = new ArrayList<>();
 
+    /** Optional key of the guided template used to write this entry (Entry Templates feature). Null for freeform entries. */
+    @Column(name = "template_key", length = 50)
+    private String templateKey;
+
     // Constructor for creating new entries
     public EntryEntity(String id, String userId, String title, String reflection, List<String> emotions) {
         this.id = Objects.requireNonNull(id, "ID cannot be null");

--- a/src/main/java/org/mentorship/reflectly/model/ProtocolUsageEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/ProtocolUsageEntity.java
@@ -1,0 +1,54 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A single logged use of an {@link ActionProtocolEntity}: when it was used and how
+ * effective it was. Kept as its own append-only log so effectiveness-over-time can be
+ * charted in a later phase without losing history.
+ */
+@Entity
+@Table(name = "protocol_usages", indexes = {
+        @Index(name = "idx_protocolusage_protocol", columnList = "protocolId"),
+        @Index(name = "idx_protocolusage_user", columnList = "userId")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProtocolUsageEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "protocol_id", nullable = false, length = 36)
+    private String protocolId;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "effectiveness", nullable = false, length = 20)
+    private EffectivenessLevel effectiveness;
+
+    @Column(name = "note", length = 500)
+    private String note;
+
+    @Column(name = "used_at", nullable = false)
+    private Instant usedAt;
+
+    public ProtocolUsageEntity(String id, String protocolId, String userId, EffectivenessLevel effectiveness, String note, Instant usedAt) {
+        this.id = Objects.requireNonNull(id, "ID cannot be null");
+        this.protocolId = Objects.requireNonNull(protocolId, "Protocol ID cannot be null");
+        this.userId = Objects.requireNonNull(userId, "User ID cannot be null");
+        this.effectiveness = Objects.requireNonNull(effectiveness, "Effectiveness cannot be null");
+        this.note = note;
+        this.usedAt = usedAt != null ? usedAt : Instant.now();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/repository/ActionProtocolRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/ActionProtocolRepository.java
@@ -1,0 +1,28 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ActionProtocolRepository extends JpaRepository<ActionProtocolEntity, String> {
+
+    /**
+     * Find all action protocols by user ID with pagination, most recently created first.
+     */
+    Page<ActionProtocolEntity> findByUserIdOrderByCreatedDateDesc(String userId, Pageable pageable);
+
+    /**
+     * Find an action protocol by ID and user ID (for security - users can only access their own protocols).
+     */
+    Optional<ActionProtocolEntity> findByIdAndUserId(String id, String userId);
+
+    /**
+     * Check if an action protocol exists and belongs to a specific user.
+     */
+    boolean existsByIdAndUserId(String id, String userId);
+}

--- a/src/main/java/org/mentorship/reflectly/repository/EnergyLogRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/EnergyLogRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,6 +17,12 @@ public interface EnergyLogRepository extends JpaRepository<EnergyLogEntity, Stri
      * Find all energy logs by user ID with pagination, most recent first.
      */
     Page<EnergyLogEntity> findByUserIdOrderByLoggedAtDesc(String userId, Pageable pageable);
+
+    /**
+     * Find energy logs within a time range (oldest first) for trend/dashboard aggregation.
+     * Bounded by range so the payload stays small and can be bucketed client-side.
+     */
+    List<EnergyLogEntity> findByUserIdAndLoggedAtBetweenOrderByLoggedAtAsc(String userId, Instant from, Instant to);
 
     /**
      * Find energy logs by user ID and context tag with pagination, most recent first.

--- a/src/main/java/org/mentorship/reflectly/repository/EnergyLogRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/EnergyLogRepository.java
@@ -1,0 +1,33 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.EnergyLogEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EnergyLogRepository extends JpaRepository<EnergyLogEntity, String> {
+
+    /**
+     * Find all energy logs by user ID with pagination, most recent first.
+     */
+    Page<EnergyLogEntity> findByUserIdOrderByLoggedAtDesc(String userId, Pageable pageable);
+
+    /**
+     * Find energy logs by user ID and context tag with pagination, most recent first.
+     */
+    Page<EnergyLogEntity> findByUserIdAndContextTagOrderByLoggedAtDesc(String userId, String contextTag, Pageable pageable);
+
+    /**
+     * Find an energy log by ID and user ID (for security - users can only access their own logs).
+     */
+    Optional<EnergyLogEntity> findByIdAndUserId(String id, String userId);
+
+    /**
+     * Check if an energy log exists and belongs to a specific user.
+     */
+    boolean existsByIdAndUserId(String id, String userId);
+}

--- a/src/main/java/org/mentorship/reflectly/repository/ProtocolUsageRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/ProtocolUsageRepository.java
@@ -1,0 +1,17 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProtocolUsageRepository extends JpaRepository<ProtocolUsageEntity, String> {
+
+    /**
+     * Find all usage log entries for a protocol, most recent first.
+     * Reserved for a future "effectiveness over time" view.
+     */
+    List<ProtocolUsageEntity> findByProtocolIdAndUserIdOrderByUsedAtDesc(String protocolId, String userId);
+}

--- a/src/main/java/org/mentorship/reflectly/service/ActionProtocolService.java
+++ b/src/main/java/org/mentorship/reflectly/service/ActionProtocolService.java
@@ -1,0 +1,106 @@
+package org.mentorship.reflectly.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.mentorship.reflectly.converter.ActionProtocolConverter;
+import org.mentorship.reflectly.dto.ActionProtocolRequestDto;
+import org.mentorship.reflectly.dto.ActionProtocolResponseDto;
+import org.mentorship.reflectly.dto.MarkProtocolUsedRequestDto;
+import org.mentorship.reflectly.exception.NotFoundException;
+import org.mentorship.reflectly.model.ActionProtocolEntity;
+import org.mentorship.reflectly.model.ProtocolUsageEntity;
+import org.mentorship.reflectly.repository.ActionProtocolRepository;
+import org.mentorship.reflectly.repository.ProtocolUsageRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Validated
+public class ActionProtocolService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final ActionProtocolRepository actionProtocolRepository;
+    private final ProtocolUsageRepository protocolUsageRepository;
+    private final ActionProtocolConverter actionProtocolConverter;
+
+    @Transactional(readOnly = true)
+    public Page<ActionProtocolResponseDto> getAllProtocols(String userId, Pageable pageable) {
+        Pageable validatedPageable = validateAndCreatePageable(pageable);
+        Page<ActionProtocolEntity> protocolPage = actionProtocolRepository.findByUserIdOrderByCreatedDateDesc(userId, validatedPageable);
+        return actionProtocolConverter.toResponseDtoPage(protocolPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ActionProtocolResponseDto getProtocolById(String userId, String protocolId) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+        return actionProtocolConverter.toResponseDto(protocol);
+    }
+
+    public ActionProtocolResponseDto createProtocol(String userId, ActionProtocolRequestDto requestDto) {
+        String protocolId = UUID.randomUUID().toString();
+        ActionProtocolEntity protocol = actionProtocolConverter.toEntity(requestDto, protocolId, userId);
+
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    public ActionProtocolResponseDto updateProtocol(String userId, String protocolId, ActionProtocolRequestDto requestDto) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+
+        actionProtocolConverter.updateEntityFromDto(requestDto, protocol);
+
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    public void deleteProtocol(String userId, String protocolId) {
+        if (!actionProtocolRepository.existsByIdAndUserId(protocolId, userId)) {
+            throw new NotFoundException("Action protocol not found");
+        }
+
+        actionProtocolRepository.deleteById(protocolId);
+    }
+
+    /**
+     * Marks a protocol as used: increments its usage counter, stamps lastUsedAt, and
+     * appends an entry to the usage log so effectiveness can be tracked over time.
+     */
+    public ActionProtocolResponseDto markUsed(String userId, String protocolId, MarkProtocolUsedRequestDto requestDto) {
+        ActionProtocolEntity protocol = actionProtocolRepository.findByIdAndUserId(protocolId, userId)
+                .orElseThrow(() -> new NotFoundException("Action protocol not found"));
+
+        Instant usedAt = Instant.now();
+        protocol.recordUsage(usedAt);
+        ActionProtocolEntity savedProtocol = actionProtocolRepository.save(protocol);
+
+        ProtocolUsageEntity usage = new ProtocolUsageEntity(
+                UUID.randomUUID().toString(),
+                protocolId,
+                userId,
+                requestDto.getEffectiveness(),
+                requestDto.getNote(),
+                usedAt
+        );
+        protocolUsageRepository.save(usage);
+
+        return actionProtocolConverter.toResponseDto(savedProtocol);
+    }
+
+    private Pageable validateAndCreatePageable(Pageable pageable) {
+        int page = Math.max(0, pageable.getPageNumber());
+        int pageSize = Math.min(Math.max(1, pageable.getPageSize()), MAX_PAGE_SIZE);
+        return PageRequest.of(page, pageSize, pageable.getSort());
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/service/EnergyLogService.java
+++ b/src/main/java/org/mentorship/reflectly/service/EnergyLogService.java
@@ -1,0 +1,62 @@
+package org.mentorship.reflectly.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.mentorship.reflectly.converter.EnergyLogConverter;
+import org.mentorship.reflectly.dto.EnergyLogRequestDto;
+import org.mentorship.reflectly.dto.EnergyLogResponseDto;
+import org.mentorship.reflectly.exception.NotFoundException;
+import org.mentorship.reflectly.model.EnergyLogEntity;
+import org.mentorship.reflectly.repository.EnergyLogRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Validated
+public class EnergyLogService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final EnergyLogRepository energyLogRepository;
+    private final EnergyLogConverter energyLogConverter;
+
+    @Transactional(readOnly = true)
+    public Page<EnergyLogResponseDto> getAllLogs(String userId, String contextTag, Pageable pageable) {
+        Pageable validatedPageable = validateAndCreatePageable(pageable);
+        Page<EnergyLogEntity> logPage = StringUtils.hasText(contextTag)
+                ? energyLogRepository.findByUserIdAndContextTagOrderByLoggedAtDesc(userId, contextTag, validatedPageable)
+                : energyLogRepository.findByUserIdOrderByLoggedAtDesc(userId, validatedPageable);
+        return energyLogConverter.toResponseDtoPage(logPage);
+    }
+
+    public EnergyLogResponseDto createLog(String userId, EnergyLogRequestDto requestDto) {
+        String logId = UUID.randomUUID().toString();
+        EnergyLogEntity log = energyLogConverter.toEntity(requestDto, logId, userId);
+
+        EnergyLogEntity savedLog = energyLogRepository.save(log);
+        return energyLogConverter.toResponseDto(savedLog);
+    }
+
+    public void deleteLog(String userId, String logId) {
+        if (!energyLogRepository.existsByIdAndUserId(logId, userId)) {
+            throw new NotFoundException("Energy log not found");
+        }
+
+        energyLogRepository.deleteById(logId);
+    }
+
+    private Pageable validateAndCreatePageable(Pageable pageable) {
+        int page = Math.max(0, pageable.getPageNumber());
+        int pageSize = Math.min(Math.max(1, pageable.getPageSize()), MAX_PAGE_SIZE);
+        return PageRequest.of(page, pageSize, pageable.getSort());
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/service/EnergyLogService.java
+++ b/src/main/java/org/mentorship/reflectly/service/EnergyLogService.java
@@ -16,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.util.StringUtils;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -25,6 +28,8 @@ import java.util.UUID;
 public class EnergyLogService {
 
     private static final int MAX_PAGE_SIZE = 100;
+    private static final int DEFAULT_RANGE_DAYS = 30;
+    private static final int MAX_RANGE_DAYS = 366;
 
     private final EnergyLogRepository energyLogRepository;
     private final EnergyLogConverter energyLogConverter;
@@ -36,6 +41,21 @@ public class EnergyLogService {
                 ? energyLogRepository.findByUserIdAndContextTagOrderByLoggedAtDesc(userId, contextTag, validatedPageable)
                 : energyLogRepository.findByUserIdOrderByLoggedAtDesc(userId, validatedPageable);
         return energyLogConverter.toResponseDtoPage(logPage);
+    }
+
+    /**
+     * Return raw energy-log points for the last {@code days} days (oldest first),
+     * bounded so the Dashboard can bucket them client-side in the user's local timezone.
+     */
+    @Transactional(readOnly = true)
+    public List<EnergyLogResponseDto> getLogsInRange(String userId, Integer days) {
+        int windowDays = days == null ? DEFAULT_RANGE_DAYS : Math.min(Math.max(1, days), MAX_RANGE_DAYS);
+        Instant to = Instant.now();
+        Instant from = to.minus(windowDays, ChronoUnit.DAYS);
+        return energyLogRepository.findByUserIdAndLoggedAtBetweenOrderByLoggedAtAsc(userId, from, to)
+                .stream()
+                .map(energyLogConverter::toResponseDto)
+                .toList();
     }
 
     public EnergyLogResponseDto createLog(String userId, EnergyLogRequestDto requestDto) {


### PR DESCRIPTION
## Summary
Integration branch for the 3 remaining Phase 1 features, built in parallel worktrees and merged in order (Templates → Dashboard → Action Protocol):
- Templates/Dashboard needed no BE work beyond the two hooks already on `develop` (`templateKey`, `/energy-logs/range`).
- Action Protocol BE (#14, merged): `/api/protocols` CRUD + `/api/protocols/{id}/use`.

## Verification
- `./mvnw.cmd clean compile` — clean
- End-to-end browser-verified against this exact branch: entry-with-template created (`templateKey` round-tripped correctly), protocol created + marked used (`usageCount`/`lastUsedAt` updated), energy-logs/range powering the FE dashboard.

Ready for your review before merging into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)