### PR TITLE
feat: Aura Insight Catcher — summary, saved framework entries, insight-person linking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,6 @@ GEMINI_API_KEY=your-gemini-key-here
 # AES-256 key for encrypting conversation message content at rest (32 bytes, base64-encoded)
 ENCRYPTION_KEY=
 
-# Whether raw conversation message content is purged after memory extraction succeeds (default true)
-# PURGE_TRANSCRIPTS=true
+# Whether raw conversation message content is purged after memory extraction succeeds (default false —
+# transcripts are kept, encrypted at rest, so users can revisit past chat history)
+# PURGE_TRANSCRIPTS=false

--- a/documentation/migrations/002-add-conversation-summary-and-saved-framework-entries.sql
+++ b/documentation/migrations/002-add-conversation-summary-and-saved-framework-entries.sql
@@ -1,0 +1,22 @@
+-- 002 — Aura Insight Catcher: conversation summaries + saved framework entries.
+-- Additive, nullable/new-table, online-safe on PostgreSQL.
+-- Run against the production DB BEFORE deploying the jar that adds
+-- ConversationEntity.summary and SavedFrameworkEntryEntity (prod runs
+-- ddl-auto: validate and will fail boot otherwise).
+
+ALTER TABLE conversations ADD COLUMN IF NOT EXISTS summary TEXT;
+
+CREATE TABLE IF NOT EXISTS saved_framework_entries (
+    id                  varchar(255) PRIMARY KEY,
+    user_id             bigint NOT NULL REFERENCES users(id),
+    conversation_id     varchar(255) REFERENCES conversations(id),
+    framework_type      varchar(20) NOT NULL,
+    title               varchar(200),
+    payload             jsonb NOT NULL,
+    created_date        timestamp(6),
+    created_by          varchar(255),
+    last_modified_date  timestamp(6),
+    last_modified_by    varchar(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_framework_entries_user ON saved_framework_entries (user_id);

--- a/documentation/migrations/003-link-insights-and-saved-entries-to-person.sql
+++ b/documentation/migrations/003-link-insights-and-saved-entries-to-person.sql
@@ -1,0 +1,10 @@
+-- 003 — Phase 2 (ACT Matrix / SWOT / Life Positions / PRM / Insight↔Person linking).
+-- Additive, nullable columns, online-safe on PostgreSQL.
+-- Run against the production DB BEFORE deploying the jar that adds InsightEntity.person and
+-- SavedFrameworkEntryEntity.person (prod runs ddl-auto: validate and will fail boot otherwise).
+
+ALTER TABLE insights ADD COLUMN IF NOT EXISTS person_id varchar(255) REFERENCES people(id);
+CREATE INDEX IF NOT EXISTS idx_insights_person ON insights (person_id);
+
+ALTER TABLE saved_framework_entries ADD COLUMN IF NOT EXISTS person_id varchar(255) REFERENCES people(id);
+CREATE INDEX IF NOT EXISTS idx_saved_framework_entries_person ON saved_framework_entries (person_id);

--- a/documentation/migrations/README.md
+++ b/documentation/migrations/README.md
@@ -22,3 +22,5 @@ against prod is a stopgap, not the plan.
 | # | File | Introduced by | Notes |
 |---|------|---------------|-------|
 | 001 | `001-add-entry-template-key.sql` | Entry Templates | Nullable column on `entries` |
+| 002 | `002-add-conversation-summary-and-saved-framework-entries.sql` | Aura Insight Catcher | Nullable column on `conversations` + new `saved_framework_entries` table |
+| 003 | `003-link-insights-and-saved-entries-to-person.sql` | Aura Insight Catcher Phase 2 | Nullable `person_id` FK columns on `insights` and `saved_framework_entries` |

--- a/src/main/java/org/mentorship/reflectly/ai/ConversationSummaryService.java
+++ b/src/main/java/org/mentorship/reflectly/ai/ConversationSummaryService.java
@@ -1,0 +1,72 @@
+package org.mentorship.reflectly.ai;
+
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import lombok.RequiredArgsConstructor;
+import org.mentorship.reflectly.constants.AiConstants;
+import org.mentorship.reflectly.model.ConversationMessageEntity;
+import org.mentorship.reflectly.model.MessageRole;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * On-demand, human-readable recap of a Coach conversation — distinct from
+ * {@link MemoryExtractionService}, which produces structured People/Events/Insights for
+ * background storage. This produces markdown prose meant to be shown directly to the user in
+ * the chat UI (e.g. after they ask to "tóm tắt" the session), and to seed the Insight Catcher
+ * save flow.
+ */
+@Service
+@RequiredArgsConstructor
+public class ConversationSummaryService {
+
+    private static final String PROMPT_TEMPLATE = """
+            Đọc đoạn hội thoại giữa Người dùng và Coach dưới đây. Viết một bản tóm tắt ngắn gọn, \
+            súc tích bằng tiếng Việt dưới dạng markdown (dùng gạch đầu dòng), nêu bật:
+            - Những insight hoặc nhận thức quan trọng người dùng đã tự đúc kết được.
+            - Các giá trị, mục tiêu, hoặc mối bận tâm cốt lõi được nhắc đến.
+            - Nếu có, các bước hành động hoặc điều người dùng muốn ghi nhớ.
+
+            Chỉ tóm tắt những gì thực sự xuất hiện trong hội thoại, không suy diễn hay bịa thêm. \
+            Giữ giọng điệu ấm áp, khách quan, không phán xét.
+
+            Hội thoại:
+            %s
+            """;
+
+    private final Client geminiClient;
+
+    public String summarize(List<ConversationMessageEntity> messages) {
+        String transcript = buildTranscript(messages);
+        if (transcript.isBlank()) {
+            return "Chưa có nội dung trò chuyện để tóm tắt.";
+        }
+
+        GenerateContentConfig config = GenerateContentConfig.builder()
+                .maxOutputTokens(AiConstants.EXTRACTION_MAX_OUTPUT_TOKENS)
+                .build();
+
+        GenerateContentResponse response = geminiClient.models.generateContent(
+                AiConstants.MEMORY_EXTRACTION_MODEL,
+                Content.builder().role("user").parts(Part.fromText(PROMPT_TEMPLATE.formatted(transcript))).build(),
+                config);
+
+        return response.text();
+    }
+
+    private String buildTranscript(List<ConversationMessageEntity> messages) {
+        StringBuilder sb = new StringBuilder();
+        for (ConversationMessageEntity message : messages) {
+            if (message.getContent() == null) {
+                continue;
+            }
+            String speaker = message.getRole() == MessageRole.USER ? "Người dùng" : "Coach";
+            sb.append(speaker).append(": ").append(message.getContent()).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/ai/ExtractionResult.java
+++ b/src/main/java/org/mentorship/reflectly/ai/ExtractionResult.java
@@ -49,5 +49,9 @@ public class ExtractionResult {
         private String insightText;
         /** One of InsightCategory enum names (VALUE, BEHAVIOR_PATTERN, RELATIONSHIP). */
         private String category;
+        /** Optional — must match a name in `people` for this same extraction if the insight is
+         * specifically about that person (typically for RELATIONSHIP-category insights). Null
+         * when the insight is about the user generally (e.g. most VALUE insights). */
+        private String personName;
     }
 }

--- a/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionPersister.java
+++ b/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionPersister.java
@@ -103,8 +103,13 @@ class MemoryExtractionPersister {
                 if (extracted.getInsightText() == null || extracted.getInsightText().isBlank()) {
                     continue;
                 }
+                // Only link to a person the model also listed in `people` for this same
+                // extraction — same "don't guess" rule as events above.
+                PersonEntity person = extracted.getPersonName() == null
+                        ? null
+                        : peopleByName.get(extracted.getPersonName().toLowerCase());
                 InsightEntity insight = new InsightEntity(
-                        UUID.randomUUID().toString(), user, conversation,
+                        UUID.randomUUID().toString(), user, conversation, person,
                         extracted.getInsightText(),
                         parseEnum(InsightCategory.class, extracted.getCategory(), InsightCategory.BEHAVIOR_PATTERN));
                 insightRepository.save(insight);

--- a/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionService.java
+++ b/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionService.java
@@ -91,7 +91,9 @@ public class MemoryExtractionService {
                 - events: các sự kiện/tương tác liên quan đến từng người ở trên, có tóm tắt ngắn gọn và \
                 điểm cảm xúc (-1 tiêu cực đến 1 tích cực).
                 - insights: nhận định ngắn gọn về giá trị cốt lõi, mẫu hành vi, hoặc mối quan hệ mà Người dùng \
-                bộc lộ qua cuộc trò chuyện — không suy diễn quá xa những gì thực sự được nói.
+                bộc lộ qua cuộc trò chuyện — không suy diễn quá xa những gì thực sự được nói. Nếu insight \
+                gắn liền với một người cụ thể đã liệt kê ở "people" (thường là loại RELATIONSHIP), điền tên \
+                người đó vào personName; nếu không, để personName là null.
                 Nếu không có thông tin phù hợp cho một mục, trả về mảng rỗng cho mục đó. Chỉ trích xuất những \
                 gì thực sự xuất hiện trong hội thoại, không bịa thêm.
 
@@ -143,7 +145,8 @@ public class MemoryExtractionService {
                 .properties(Map.of(
                         "insightText", Schema.builder().type(Type.Known.STRING).build(),
                         "category", Schema.builder().type(Type.Known.STRING)
-                                .enum_("VALUE", "BEHAVIOR_PATTERN", "RELATIONSHIP").build()))
+                                .enum_("VALUE", "BEHAVIOR_PATTERN", "RELATIONSHIP").build(),
+                        "personName", Schema.builder().type(Type.Known.STRING).build()))
                 .required("insightText", "category")
                 .build();
 

--- a/src/main/java/org/mentorship/reflectly/controller/ConversationController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/ConversationController.java
@@ -113,6 +113,20 @@ public class ConversationController {
         return ResponseEntity.ok(conversationService.endConversation(userId, id));
     }
 
+    @Operation(summary = "Summarize a conversation", description = "Generates (and persists) a markdown recap of the conversation so far; callable any time, safe to re-call to regenerate")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Summary generated successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Conversation not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping("/{id}/summarize")
+    public ResponseEntity<ConversationResponseDto> summarizeConversation(
+            @Parameter(description = "Conversation ID") @PathVariable String id,
+            GoogleAuthenticationToken authentication) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        return ResponseEntity.ok(conversationService.summarizeConversation(userId, id));
+    }
+
     private Long getUserIdFromAuthentication(GoogleAuthenticationToken authentication) {
         if (authentication != null && authentication.getUser() != null) {
             return authentication.getUser().getId();

--- a/src/main/java/org/mentorship/reflectly/controller/InsightController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/InsightController.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -27,7 +28,7 @@ public class InsightController {
 
     private final InsightService insightService;
 
-    @Operation(summary = "List insights", description = "Get the current user's insight timeline, paginated, newest first")
+    @Operation(summary = "List insights", description = "Get the current user's insight timeline, paginated, newest first, optionally filtered to one person")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Insights retrieved successfully"),
             @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
@@ -35,9 +36,10 @@ public class InsightController {
     @GetMapping
     public ResponseEntity<PagedResponseDto<InsightResponseDto>> getAllInsights(
             GoogleAuthenticationToken authentication,
+            @RequestParam(required = false) String personId,
             @ParameterObject Pageable pageable) {
         Long userId = getUserIdFromAuthentication(authentication);
-        Page<InsightResponseDto> pageResult = insightService.getAllInsights(userId, pageable);
+        Page<InsightResponseDto> pageResult = insightService.getAllInsights(userId, personId, pageable);
 
         String nextLink = null;
         if (pageResult.hasNext()) {

--- a/src/main/java/org/mentorship/reflectly/controller/SavedFrameworkEntryController.java
+++ b/src/main/java/org/mentorship/reflectly/controller/SavedFrameworkEntryController.java
@@ -1,0 +1,129 @@
+package org.mentorship.reflectly.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.mentorship.reflectly.constants.ApiConstants;
+import org.mentorship.reflectly.dto.PagedResponseDto;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryRequestDto;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryResponseDto;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryUpdateRequestDto;
+import org.mentorship.reflectly.model.FrameworkType;
+import org.mentorship.reflectly.security.GoogleAuthenticationToken;
+import org.mentorship.reflectly.service.SavedFrameworkEntryService;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/saved-framework-entries")
+@Tag(name = "Saved Framework Entries", description = "User-captured, editable structured insights (Free-form, Johari Window, ...) shown on Đúc kết")
+@RequiredArgsConstructor
+public class SavedFrameworkEntryController {
+
+    private final SavedFrameworkEntryService savedFrameworkEntryService;
+
+    @Operation(summary = "List saved framework entries", description = "Paginated, newest first, optionally filtered by frameworkType")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Entries retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<SavedFrameworkEntryResponseDto>> getAllEntries(
+            GoogleAuthenticationToken authentication,
+            @Parameter(description = "Optional filter by framework type") @RequestParam(required = false) FrameworkType frameworkType,
+            @ParameterObject Pageable pageable) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        Page<SavedFrameworkEntryResponseDto> page = savedFrameworkEntryService.getAllEntries(userId, frameworkType, pageable);
+
+        String nextLink = null;
+        if (page.hasNext()) {
+            nextLink = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .replaceQueryParam("page", page.getNumber() + 1)
+                    .toUriString();
+        }
+
+        return ResponseEntity.ok(new PagedResponseDto<>(page.getContent(), page.getTotalElements(), nextLink));
+    }
+
+    @Operation(summary = "Get a saved framework entry by ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Entry retrieved successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Entry not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<SavedFrameworkEntryResponseDto> getEntryById(
+            @Parameter(description = "Entry ID") @PathVariable String id,
+            GoogleAuthenticationToken authentication) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        return ResponseEntity.ok(savedFrameworkEntryService.getEntryById(userId, id));
+    }
+
+    @Operation(summary = "Save a framework entry", description = "Captures a structured insight (Free-form, Johari Window, ...), optionally linked to a Coach conversation")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.CREATED, description = "Entry created successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Referenced conversation not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PostMapping
+    public ResponseEntity<SavedFrameworkEntryResponseDto> createEntry(
+            @Valid @RequestBody SavedFrameworkEntryRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        SavedFrameworkEntryResponseDto entry = savedFrameworkEntryService.createEntry(userId, requestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(entry.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(entry);
+    }
+
+    @Operation(summary = "Update a saved framework entry", description = "Edits title/payload; the framework type and source conversation are immutable")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.SUCCESS, description = "Entry updated successfully"),
+            @ApiResponse(responseCode = ApiConstants.BAD_REQUEST, description = "Validation error"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Entry not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<SavedFrameworkEntryResponseDto> updateEntry(
+            @Parameter(description = "Entry ID") @PathVariable String id,
+            @Valid @RequestBody SavedFrameworkEntryUpdateRequestDto requestDto,
+            GoogleAuthenticationToken authentication) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        return ResponseEntity.ok(savedFrameworkEntryService.updateEntry(userId, id, requestDto));
+    }
+
+    @Operation(summary = "Delete a saved framework entry")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = ApiConstants.NO_CONTENT, description = "Entry deleted successfully"),
+            @ApiResponse(responseCode = ApiConstants.NOT_FOUND, description = "Entry not found"),
+            @ApiResponse(responseCode = ApiConstants.UNAUTHORIZED, description = "Invalid or missing authentication token")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEntry(
+            @Parameter(description = "Entry ID") @PathVariable String id,
+            GoogleAuthenticationToken authentication) {
+        Long userId = getUserIdFromAuthentication(authentication);
+        savedFrameworkEntryService.deleteEntry(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private Long getUserIdFromAuthentication(GoogleAuthenticationToken authentication) {
+        if (authentication != null && authentication.getUser() != null) {
+            return authentication.getUser().getId();
+        }
+        throw new RuntimeException(ApiConstants.USER_NOT_AUTHENTICATED);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/converter/ConversationConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/ConversationConverter.java
@@ -27,6 +27,7 @@ public class ConversationConverter {
                 .startedAt(entity.getStartedAt())
                 .endedAt(entity.getEndedAt())
                 .messages(messages.stream().map(this::toMessageResponseDto).toList())
+                .summary(entity.getSummary())
                 .build();
     }
 }

--- a/src/main/java/org/mentorship/reflectly/converter/InsightConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/InsightConverter.java
@@ -14,6 +14,8 @@ public class InsightConverter {
                 .insightText(entity.getInsightText())
                 .category(entity.getCategory())
                 .createdAt(entity.getCreatedDate())
+                .personId(entity.getPerson() != null ? entity.getPerson().getId() : null)
+                .personName(entity.getPerson() != null ? entity.getPerson().getName() : null)
                 .build();
     }
 

--- a/src/main/java/org/mentorship/reflectly/converter/SavedFrameworkEntryConverter.java
+++ b/src/main/java/org/mentorship/reflectly/converter/SavedFrameworkEntryConverter.java
@@ -1,0 +1,26 @@
+package org.mentorship.reflectly.converter;
+
+import org.mentorship.reflectly.dto.SavedFrameworkEntryResponseDto;
+import org.mentorship.reflectly.model.SavedFrameworkEntryEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavedFrameworkEntryConverter {
+
+    public SavedFrameworkEntryResponseDto toResponseDto(SavedFrameworkEntryEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return SavedFrameworkEntryResponseDto.builder()
+                .id(entity.getId())
+                .frameworkType(entity.getFrameworkType())
+                .title(entity.getTitle())
+                .payload(entity.getPayload())
+                .conversationId(entity.getConversation() != null ? entity.getConversation().getId() : null)
+                .personId(entity.getPerson() != null ? entity.getPerson().getId() : null)
+                .personName(entity.getPerson() != null ? entity.getPerson().getName() : null)
+                .createdAt(entity.getCreatedDate())
+                .updatedAt(entity.getLastModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/dto/ConversationResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/ConversationResponseDto.java
@@ -19,4 +19,7 @@ public class ConversationResponseDto {
     private Instant startedAt;
     private Instant endedAt;
     private List<ConversationMessageResponseDto> messages;
+
+    /** AI-generated markdown recap, null until requested via POST /{id}/summarize. */
+    private String summary;
 }

--- a/src/main/java/org/mentorship/reflectly/dto/InsightResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/InsightResponseDto.java
@@ -17,4 +17,8 @@ public class InsightResponseDto {
     private String insightText;
     private InsightCategory category;
     private Instant createdAt;
+
+    /** Which person (relationship map) this insight is about, if known. Null otherwise. */
+    private String personId;
+    private String personName;
 }

--- a/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryRequestDto.java
@@ -1,0 +1,33 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.FrameworkType;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavedFrameworkEntryRequestDto {
+
+    @NotNull(message = "Framework type is required")
+    private FrameworkType frameworkType;
+
+    @Size(max = 200, message = "Title must not exceed 200 characters")
+    private String title;
+
+    @NotEmpty(message = "Payload is required")
+    private Map<String, Object> payload;
+
+    /** Optional — which chat this was captured from, if any. */
+    private String conversationId;
+
+    /** Optional — which person (relationship map) this entry is about. Required in practice for
+     * LIFE_POSITIONS, unused by the other framework types. */
+    private String personId;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryResponseDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryResponseDto.java
@@ -1,0 +1,27 @@
+package org.mentorship.reflectly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.mentorship.reflectly.model.FrameworkType;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavedFrameworkEntryResponseDto {
+
+    private String id;
+    private FrameworkType frameworkType;
+    private String title;
+    private Map<String, Object> payload;
+    private String conversationId;
+    private String personId;
+    private String personName;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryUpdateRequestDto.java
+++ b/src/main/java/org/mentorship/reflectly/dto/SavedFrameworkEntryUpdateRequestDto.java
@@ -1,0 +1,31 @@
+package org.mentorship.reflectly.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Update payload for a saved framework entry — deliberately excludes frameworkType and
+ * conversationId, which are immutable after creation (see SavedFrameworkEntryService.updateEntry).
+ * Kept separate from SavedFrameworkEntryRequestDto (create) so its @NotNull frameworkType
+ * validation doesn't apply here.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavedFrameworkEntryUpdateRequestDto {
+
+    @Size(max = 200, message = "Title must not exceed 200 characters")
+    private String title;
+
+    @NotEmpty(message = "Payload is required")
+    private Map<String, Object> payload;
+
+    /** Optional — which person (relationship map) this entry is about; editable, unlike
+     * frameworkType/conversationId. Pass null/omit to clear it. */
+    private String personId;
+}

--- a/src/main/java/org/mentorship/reflectly/model/ConversationEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/ConversationEntity.java
@@ -34,6 +34,16 @@ public class ConversationEntity extends AuditableEntity {
     @Column(name = "ended_at")
     private Instant endedAt;
 
+    /**
+     * AI-generated human-readable recap of the conversation (Vietnamese, markdown-formatted),
+     * generated on demand via {@code POST /api/conversations/{id}/summarize} — not tied to
+     * ending the session, and re-generatable. Encrypted at rest like message content, since it
+     * can restate personal details from the conversation.
+     */
+    @Convert(converter = org.mentorship.reflectly.converter.EncryptedStringConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
     public ConversationEntity(String id, UserEntity user) {
         this.id = id;
         this.user = user;

--- a/src/main/java/org/mentorship/reflectly/model/FrameworkType.java
+++ b/src/main/java/org/mentorship/reflectly/model/FrameworkType.java
@@ -1,0 +1,14 @@
+package org.mentorship.reflectly.model;
+
+/**
+ * Which structured "insight catcher" template a {@link SavedFrameworkEntryEntity} was captured
+ * with. Only FREEFORM and JOHARI_WINDOW are reachable via the API/UI today (Phase 1) — the rest
+ * are reserved so a later phase can add them without a schema change.
+ */
+public enum FrameworkType {
+    FREEFORM,
+    JOHARI_WINDOW,
+    ACT_MATRIX,
+    PERSONAL_SWOT,
+    LIFE_POSITIONS
+}

--- a/src/main/java/org/mentorship/reflectly/model/InsightEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/InsightEntity.java
@@ -26,6 +26,13 @@ public class InsightEntity extends AuditableEntity {
     @JoinColumn(name = "conversation_id")
     private ConversationEntity conversation;
 
+    /** Which person (relationship map) this insight is about, if the extraction could tell —
+     * links "Thấu hiểu"'s insight timeline to the relationship map (Phase 2). Nullable: not every
+     * insight is about a specific person (e.g. VALUE-category insights usually aren't). */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "person_id")
+    private PersonEntity person;
+
     @Column(name = "insight_text", nullable = false, columnDefinition = "TEXT")
     private String insightText;
 
@@ -38,6 +45,16 @@ public class InsightEntity extends AuditableEntity {
         this.id = id;
         this.user = user;
         this.conversation = conversation;
+        this.insightText = insightText;
+        this.category = category;
+    }
+
+    public InsightEntity(String id, UserEntity user, ConversationEntity conversation, PersonEntity person,
+                          String insightText, InsightCategory category) {
+        this.id = id;
+        this.user = user;
+        this.conversation = conversation;
+        this.person = person;
         this.insightText = insightText;
         this.category = category;
     }

--- a/src/main/java/org/mentorship/reflectly/model/SavedFrameworkEntryEntity.java
+++ b/src/main/java/org/mentorship/reflectly/model/SavedFrameworkEntryEntity.java
@@ -1,0 +1,78 @@
+package org.mentorship.reflectly.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+/**
+ * A user-authored, editable structured entry captured from (or inspired by) a Coach chat —
+ * e.g. a Johari Window or a free-form log — shown and editable on "Đúc kết". Deliberately not
+ * named Insight*: that name is already used by {@link InsightEntity}, the AI-derived, read-only
+ * timeline shown on "Thấu hiểu". This entity is the opposite: user-owned and editable.
+ * <p>
+ * One table serves every {@link FrameworkType} via a JSONB {@code payload} rather than a table
+ * per framework, so adding a new framework later is additive (new enum value + FE form), not a
+ * migration.
+ */
+@Entity
+@Table(name = "saved_framework_entries", indexes = {
+        @Index(name = "idx_saved_framework_entries_user", columnList = "user_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SavedFrameworkEntryEntity extends AuditableEntity {
+
+    @Id
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    /** Which chat this was captured from, if any — free-standing entries are allowed too. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conversation_id")
+    private ConversationEntity conversation;
+
+    /** Which person (relationship map) this entry is about — used by LIFE_POSITIONS, which is
+     * always about one specific relationship. Null for the "về bản thân" frameworks. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "person_id")
+    private PersonEntity person;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "framework_type", nullable = false, length = 20)
+    private FrameworkType frameworkType;
+
+    @Column(length = 200)
+    private String title;
+
+    /**
+     * Shape depends on {@link #frameworkType}: FREEFORM = {@code {content, tags[]}};
+     * JOHARI_WINDOW = {@code {open, blind, hidden, unknown}}; ACT_MATRIX =
+     * {@code {fiveSenses, values, awayMoves, towardMoves}}; PERSONAL_SWOT =
+     * {@code {strengths, weaknesses, opportunities, threats}}; LIFE_POSITIONS =
+     * {@code {position, notes}} (position is one of the LifePosition enum names — see FE model).
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> payload;
+
+    public SavedFrameworkEntryEntity(String id, UserEntity user, ConversationEntity conversation, PersonEntity person,
+                                      FrameworkType frameworkType, String title, Map<String, Object> payload) {
+        this.id = id;
+        this.user = user;
+        this.conversation = conversation;
+        this.person = person;
+        this.frameworkType = frameworkType;
+        this.title = title;
+        this.payload = payload;
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/repository/InsightRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/InsightRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface InsightRepository extends JpaRepository<InsightEntity, String> {
 
     Page<InsightEntity> findByUserIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
+
+    Page<InsightEntity> findByUserIdAndPersonIdOrderByCreatedDateDesc(Long userId, String personId, Pageable pageable);
 }

--- a/src/main/java/org/mentorship/reflectly/repository/SavedFrameworkEntryRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/SavedFrameworkEntryRepository.java
@@ -1,0 +1,21 @@
+package org.mentorship.reflectly.repository;
+
+import org.mentorship.reflectly.model.FrameworkType;
+import org.mentorship.reflectly.model.SavedFrameworkEntryEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SavedFrameworkEntryRepository extends JpaRepository<SavedFrameworkEntryEntity, String> {
+
+    Page<SavedFrameworkEntryEntity> findByUserIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
+
+    Page<SavedFrameworkEntryEntity> findByUserIdAndFrameworkTypeOrderByCreatedDateDesc(
+            Long userId, FrameworkType frameworkType, Pageable pageable);
+
+    Optional<SavedFrameworkEntryEntity> findByIdAndUserId(String id, Long userId);
+}

--- a/src/main/java/org/mentorship/reflectly/service/ConversationService.java
+++ b/src/main/java/org/mentorship/reflectly/service/ConversationService.java
@@ -3,6 +3,7 @@ package org.mentorship.reflectly.service;
 import lombok.RequiredArgsConstructor;
 import org.mentorship.reflectly.ai.CoachAgentService;
 import org.mentorship.reflectly.ai.ConversationEndedEvent;
+import org.mentorship.reflectly.ai.ConversationSummaryService;
 import org.mentorship.reflectly.converter.ConversationConverter;
 import org.mentorship.reflectly.dto.ConversationMessageResponseDto;
 import org.mentorship.reflectly.dto.ConversationResponseDto;
@@ -31,6 +32,7 @@ public class ConversationService {
     private final UserRepository userRepository;
     private final ConversationConverter conversationConverter;
     private final CoachAgentService coachAgentService;
+    private final ConversationSummaryService conversationSummaryService;
     private final ApplicationEventPublisher eventPublisher;
 
     public ConversationResponseDto startConversation(Long userId) {
@@ -96,6 +98,22 @@ public class ConversationService {
         }
         List<ConversationMessageEntity> messages =
                 conversationMessageRepository.findByConversationIdOrderByCreatedDateAsc(conversationId);
+        return conversationConverter.toResponseDto(conversation, messages);
+    }
+
+    /**
+     * Generates (and persists) a human-readable markdown recap of the conversation so far.
+     * Callable any time — while ACTIVE or after ENDED — and safe to call again to regenerate.
+     */
+    public ConversationResponseDto summarizeConversation(Long userId, String conversationId) {
+        ConversationEntity conversation = findOwnedConversation(userId, conversationId);
+        List<ConversationMessageEntity> messages =
+                conversationMessageRepository.findByConversationIdOrderByCreatedDateAsc(conversationId);
+
+        String summary = conversationSummaryService.summarize(messages);
+        conversation.setSummary(summary);
+        conversationRepository.save(conversation);
+
         return conversationConverter.toResponseDto(conversation, messages);
     }
 

--- a/src/main/java/org/mentorship/reflectly/service/InsightService.java
+++ b/src/main/java/org/mentorship/reflectly/service/InsightService.java
@@ -21,12 +21,14 @@ public class InsightService {
     private final InsightRepository insightRepository;
     private final InsightConverter insightConverter;
 
-    public Page<InsightResponseDto> getAllInsights(Long userId, Pageable pageable) {
+    public Page<InsightResponseDto> getAllInsights(Long userId, String personId, Pageable pageable) {
         int page = Math.max(0, pageable.getPageNumber());
         int pageSize = Math.min(Math.max(1, pageable.getPageSize()), MAX_PAGE_SIZE);
         Pageable validated = PageRequest.of(page, pageSize, pageable.getSort());
 
-        Page<InsightEntity> insightPage = insightRepository.findByUserIdOrderByCreatedDateDesc(userId, validated);
+        Page<InsightEntity> insightPage = (personId == null || personId.isBlank())
+                ? insightRepository.findByUserIdOrderByCreatedDateDesc(userId, validated)
+                : insightRepository.findByUserIdAndPersonIdOrderByCreatedDateDesc(userId, personId, validated);
         return insightConverter.toResponseDtoPage(insightPage);
     }
 }

--- a/src/main/java/org/mentorship/reflectly/service/SavedFrameworkEntryService.java
+++ b/src/main/java/org/mentorship/reflectly/service/SavedFrameworkEntryService.java
@@ -1,0 +1,107 @@
+package org.mentorship.reflectly.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mentorship.reflectly.converter.SavedFrameworkEntryConverter;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryRequestDto;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryResponseDto;
+import org.mentorship.reflectly.dto.SavedFrameworkEntryUpdateRequestDto;
+import org.mentorship.reflectly.exception.NotFoundException;
+import org.mentorship.reflectly.model.ConversationEntity;
+import org.mentorship.reflectly.model.FrameworkType;
+import org.mentorship.reflectly.model.PersonEntity;
+import org.mentorship.reflectly.model.SavedFrameworkEntryEntity;
+import org.mentorship.reflectly.model.UserEntity;
+import org.mentorship.reflectly.repository.ConversationRepository;
+import org.mentorship.reflectly.repository.PersonRepository;
+import org.mentorship.reflectly.repository.SavedFrameworkEntryRepository;
+import org.mentorship.reflectly.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SavedFrameworkEntryService {
+
+    private final SavedFrameworkEntryRepository savedFrameworkEntryRepository;
+    private final ConversationRepository conversationRepository;
+    private final PersonRepository personRepository;
+    private final UserRepository userRepository;
+    private final SavedFrameworkEntryConverter converter;
+
+    @Transactional(readOnly = true)
+    public Page<SavedFrameworkEntryResponseDto> getAllEntries(Long userId, FrameworkType frameworkType, Pageable pageable) {
+        Page<SavedFrameworkEntryEntity> page = frameworkType == null
+                ? savedFrameworkEntryRepository.findByUserIdOrderByCreatedDateDesc(userId, pageable)
+                : savedFrameworkEntryRepository.findByUserIdAndFrameworkTypeOrderByCreatedDateDesc(userId, frameworkType, pageable);
+        return page.map(converter::toResponseDto);
+    }
+
+    @Transactional(readOnly = true)
+    public SavedFrameworkEntryResponseDto getEntryById(Long userId, String id) {
+        return converter.toResponseDto(findOwnedEntry(userId, id));
+    }
+
+    public SavedFrameworkEntryResponseDto createEntry(Long userId, SavedFrameworkEntryRequestDto requestDto) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+
+        ConversationEntity conversation = null;
+        if (requestDto.getConversationId() != null && !requestDto.getConversationId().isBlank()) {
+            conversation = conversationRepository.findByIdAndUserId(requestDto.getConversationId(), userId)
+                    .orElseThrow(() -> new NotFoundException("Conversation not found"));
+        }
+
+        PersonEntity person = null;
+        if (requestDto.getPersonId() != null && !requestDto.getPersonId().isBlank()) {
+            person = personRepository.findByIdAndUserId(requestDto.getPersonId(), userId)
+                    .orElseThrow(() -> new NotFoundException("Person not found"));
+        }
+
+        SavedFrameworkEntryEntity entry = new SavedFrameworkEntryEntity(
+                UUID.randomUUID().toString(),
+                user,
+                conversation,
+                person,
+                requestDto.getFrameworkType(),
+                requestDto.getTitle(),
+                requestDto.getPayload()
+        );
+
+        SavedFrameworkEntryEntity saved = savedFrameworkEntryRepository.save(entry);
+        return converter.toResponseDto(saved);
+    }
+
+    public SavedFrameworkEntryResponseDto updateEntry(Long userId, String id, SavedFrameworkEntryUpdateRequestDto requestDto) {
+        SavedFrameworkEntryEntity entry = findOwnedEntry(userId, id);
+
+        entry.setTitle(requestDto.getTitle());
+        entry.setPayload(requestDto.getPayload());
+        // frameworkType and conversation link are intentionally immutable after creation —
+        // editing swaps content within the same template, not what template/source it came from.
+        // personId IS editable (e.g. correcting which relationship a LIFE_POSITIONS entry is about).
+        if (requestDto.getPersonId() == null || requestDto.getPersonId().isBlank()) {
+            entry.setPerson(null);
+        } else {
+            entry.setPerson(personRepository.findByIdAndUserId(requestDto.getPersonId(), userId)
+                    .orElseThrow(() -> new NotFoundException("Person not found")));
+        }
+
+        SavedFrameworkEntryEntity saved = savedFrameworkEntryRepository.save(entry);
+        return converter.toResponseDto(saved);
+    }
+
+    public void deleteEntry(Long userId, String id) {
+        SavedFrameworkEntryEntity entry = findOwnedEntry(userId, id);
+        savedFrameworkEntryRepository.delete(entry);
+    }
+
+    private SavedFrameworkEntryEntity findOwnedEntry(Long userId, String id) {
+        return savedFrameworkEntryRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new NotFoundException("Saved framework entry not found"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,4 +35,4 @@ app:
   encryption:
     key: ${ENCRYPTION_KEY:}
   conversations:
-    purge-after-extraction: ${PURGE_TRANSCRIPTS:true}
+    purge-after-extraction: ${PURGE_TRANSCRIPTS:false}


### PR DESCRIPTION
## Summary
Backend for the Aura chat upgrade: on-demand session summaries, a generic saved-framework-entry model (Free-form / Johari Window / ACT Matrix / Personal SWOT / Life Positions), and linking insights + saved entries to people on the relationship map.

- Stop purging chat transcripts after extraction (`purge-after-extraction` now defaults to `false`) so past sessions stay reviewable.
- `POST /api/conversations/{id}/summarize` — Gemini-backed markdown recap, persisted on `ConversationEntity.summary`.
- New `SavedFrameworkEntryEntity` (JSONB payload, one table for all frameworks) + CRUD at `/api/saved-framework-entries`.
- `SavedFrameworkEntry` and `Insight` can now link to a `Person` (Life Positions is always about a specific relationship; extraction can now tag an insight with the person it's about).
- `GET /api/insights?personId=` filter.
- Manual migration SQL (`002`, `003`) per this repo's no-Flyway convention — must run against prod before deploy.

## Testing
- `mvn verify -DskipTests` passes.
- Manually verified end-to-end against a live Gemini-backed dev server: summarize, save each framework type, PRM person add, Life Positions linked to a person, transcript retained after ending a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)