### PR TITLE
feat(security): bound Gemini API abuse before public launch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
             <artifactId>google-genai</artifactId>
             <version>1.51.0</version>
         </dependency>
+
+        <!-- In-memory rate limiting (per-IP on auth, per-user on Coach chat) -->
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>8.19.0</version>
+        </dependency>
         <!--
           google-genai-1.51.0.jar bundles a stray META-INF/services entry advertising
           com.fasterxml.jackson.module.kotlin.KotlinModule as a Jackson module provider, without

--- a/src/main/java/org/mentorship/reflectly/ai/CoachAgentService.java
+++ b/src/main/java/org/mentorship/reflectly/ai/CoachAgentService.java
@@ -6,6 +6,7 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.Part;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mentorship.reflectly.constants.AiConstants;
 import org.mentorship.reflectly.model.ConversationMessageEntity;
 import org.mentorship.reflectly.model.MessageRole;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
  * concludes or diagnoses for them. Not a therapy/crisis-intervention tool: on distress signals
  * it acknowledges concern and points toward professional support, nothing more.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CoachAgentService {
@@ -82,7 +84,18 @@ public class CoachAgentService {
                 .build();
 
         GenerateContentResponse response = geminiClient.models.generateContent(AiConstants.COACH_MODEL, contents, config);
+        logTokenUsage("coach reply", response);
         return response.text();
+    }
+
+    /** Best-effort spend visibility in Azure logs — no dashboard, just something to grep. */
+    private void logTokenUsage(String callSite, GenerateContentResponse response) {
+        response.usageMetadata().ifPresent(usage -> log.info(
+                "Gemini tokens used ({}): total={}, prompt={}, candidates={}",
+                callSite,
+                usage.totalTokenCount().orElse(null),
+                usage.promptTokenCount().orElse(null),
+                usage.candidatesTokenCount().orElse(null)));
     }
 
     private String buildSystemPrompt(List<String> coreValues) {

--- a/src/main/java/org/mentorship/reflectly/ai/ConversationSummaryService.java
+++ b/src/main/java/org/mentorship/reflectly/ai/ConversationSummaryService.java
@@ -6,6 +6,7 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.Part;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mentorship.reflectly.constants.AiConstants;
 import org.mentorship.reflectly.model.ConversationMessageEntity;
 import org.mentorship.reflectly.model.MessageRole;
@@ -20,6 +21,7 @@ import java.util.List;
  * the chat UI (e.g. after they ask to "tóm tắt" the session), and to seed the Insight Catcher
  * save flow.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConversationSummaryService {
@@ -54,6 +56,12 @@ public class ConversationSummaryService {
                 AiConstants.MEMORY_EXTRACTION_MODEL,
                 Content.builder().role("user").parts(Part.fromText(PROMPT_TEMPLATE.formatted(transcript))).build(),
                 config);
+
+        response.usageMetadata().ifPresent(usage -> log.info(
+                "Gemini tokens used (conversation summary): total={}, prompt={}, candidates={}",
+                usage.totalTokenCount().orElse(null),
+                usage.promptTokenCount().orElse(null),
+                usage.candidatesTokenCount().orElse(null)));
 
         return response.text();
     }

--- a/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionService.java
+++ b/src/main/java/org/mentorship/reflectly/ai/MemoryExtractionService.java
@@ -112,6 +112,12 @@ public class MemoryExtractionService {
                 Content.builder().role("user").parts(Part.fromText(prompt)).build(),
                 config);
 
+        response.usageMetadata().ifPresent(usage -> log.info(
+                "Gemini tokens used (memory extraction): total={}, prompt={}, candidates={}",
+                usage.totalTokenCount().orElse(null),
+                usage.promptTokenCount().orElse(null),
+                usage.candidatesTokenCount().orElse(null)));
+
         try {
             return objectMapper.readValue(response.text(), ExtractionResult.class);
         } catch (Exception e) {

--- a/src/main/java/org/mentorship/reflectly/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/mentorship/reflectly/exception/GlobalExceptionHandler.java
@@ -27,6 +27,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(error);
     }
 
+    @ExceptionHandler(LocalAuthDisabledException.class)
+    public ResponseEntity<ErrorResponseDto> handleLocalAuthDisabled(LocalAuthDisabledException ex) {
+        ErrorResponseDto error = ErrorResponseDto.builder()
+                .message(ex.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
+
+    @ExceptionHandler(QuotaExceededException.class)
+    public ResponseEntity<ErrorResponseDto> handleQuotaExceeded(QuotaExceededException ex) {
+        ErrorResponseDto error = ErrorResponseDto.builder()
+                .message(ex.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(error);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> handleValidationExceptions(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().stream()

--- a/src/main/java/org/mentorship/reflectly/exception/LocalAuthDisabledException.java
+++ b/src/main/java/org/mentorship/reflectly/exception/LocalAuthDisabledException.java
@@ -1,0 +1,15 @@
+package org.mentorship.reflectly.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when username/password login or signup is attempted while
+ * {@code app.auth.local-credentials-enabled} is disabled (production: Google login only).
+ */
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class LocalAuthDisabledException extends RuntimeException {
+    public LocalAuthDisabledException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/exception/QuotaExceededException.java
+++ b/src/main/java/org/mentorship/reflectly/exception/QuotaExceededException.java
@@ -1,0 +1,15 @@
+package org.mentorship.reflectly.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when a user hits a hard usage quota (e.g. max conversations per account) put in place
+ * during the pre-launch/alpha phase to bound Gemini API spend.
+ */
+@ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+public class QuotaExceededException extends RuntimeException {
+    public QuotaExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/repository/ConversationRepository.java
+++ b/src/main/java/org/mentorship/reflectly/repository/ConversationRepository.java
@@ -14,4 +14,6 @@ public interface ConversationRepository extends JpaRepository<ConversationEntity
     Page<ConversationEntity> findByUserIdOrderByStartedAtDesc(Long userId, Pageable pageable);
 
     Optional<ConversationEntity> findByIdAndUserId(String id, Long userId);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/org/mentorship/reflectly/security/RateLimitFilter.java
+++ b/src/main/java/org/mentorship/reflectly/security/RateLimitFilter.java
@@ -1,0 +1,116 @@
+package org.mentorship.reflectly.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.mentorship.reflectly.dto.ErrorResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cheap in-memory rate limiting to blunt scripted abuse while this app has no CAPTCHA/paid tier
+ * of its own. Two independent buckets, both reset on app restart/scale (acceptable at the current
+ * single-instance scale — revisit with a shared store like Redis if that changes):
+ * <ul>
+ *   <li>Per-IP on {@code /api/auth/**} — the only unauthenticated surface, so IP is the only key
+ *   available; blunts credential-stuffing / signup hammering.</li>
+ *   <li>Per-user on {@code POST /api/conversations/**} — the endpoints that call Gemini; blunts a
+ *   single (even legitimate) account hammering the Coach.</li>
+ * </ul>
+ * Must run after authentication has been resolved (see SecurityConfig filter ordering) so the
+ * per-user bucket can key off the authenticated user rather than always falling back to IP.
+ */
+@Component
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.rate-limit.auth-requests-per-minute:10}")
+    private int authRequestsPerMinute;
+
+    @Value("${app.rate-limit.conversation-requests-per-minute:10}")
+    private int conversationRequestsPerMinute;
+
+    private final Map<String, Bucket> authBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> conversationBuckets = new ConcurrentHashMap<>();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !isRateLimited(request);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Bucket bucket = isAuthRoute(request)
+                ? authBuckets.computeIfAbsent(clientIp(request), key -> newBucket(authRequestsPerMinute))
+                : conversationBuckets.computeIfAbsent(conversationRateLimitKey(request),
+                        key -> newBucket(conversationRequestsPerMinute));
+
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response);
+        } else {
+            sendTooManyRequests(response);
+        }
+    }
+
+    private boolean isRateLimited(HttpServletRequest request) {
+        return isAuthRoute(request) || isConversationWrite(request);
+    }
+
+    private boolean isAuthRoute(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/api/auth/");
+    }
+
+    private boolean isConversationWrite(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/api/conversations")
+                && "POST".equalsIgnoreCase(request.getMethod());
+    }
+
+    private String conversationRateLimitKey(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof GoogleAuthenticationToken googleAuth && googleAuth.getUser() != null) {
+            return "user:" + googleAuth.getUser().getId();
+        }
+        // Shouldn't normally happen (this route requires auth), but fall back to IP rather than
+        // letting an unauthenticated edge case bypass rate limiting entirely.
+        return "ip:" + clientIp(request);
+    }
+
+    private Bucket newBucket(int requestsPerMinute) {
+        Bandwidth limit = Bandwidth.classic(requestsPerMinute, Refill.greedy(requestsPerMinute, Duration.ofMinutes(1)));
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private void sendTooManyRequests(HttpServletResponse response) throws IOException {
+        ErrorResponseDto error = ErrorResponseDto.builder()
+                .message("Bạn đang thao tác quá nhanh, vui lòng thử lại sau ít phút.")
+                .build();
+        response.setStatus(429); // HttpServletResponse has no SC_TOO_MANY_REQUESTS constant
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/src/main/java/org/mentorship/reflectly/security/SecurityConfig.java
+++ b/src/main/java/org/mentorship/reflectly/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
     private final JwtExpirationFilter jwtExpirationFilter;
     private final BackendJwtAuthenticationFilter backendJwtAuthenticationFilter;
     private final PrivateNetworkAccessFilter privateNetworkAccessFilter;
+    private final RateLimitFilter rateLimitFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -51,6 +52,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .addFilterBefore(backendJwtAuthenticationFilter, BearerTokenAuthenticationFilter.class)
                 .addFilterAfter(jwtExpirationFilter, BearerTokenAuthenticationFilter.class)
+                // Runs after auth is resolved so it can rate-limit Coach endpoints per-user
+                // rather than always falling back to IP.
+                .addFilterAfter(rateLimitFilter, JwtExpirationFilter.class)
                 .oauth2ResourceServer(configurer -> configurer
                         .bearerTokenResolver(skipIfAlreadyAuthenticated())
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(googleAuthenticationConverter)));

--- a/src/main/java/org/mentorship/reflectly/service/AuthService.java
+++ b/src/main/java/org/mentorship/reflectly/service/AuthService.java
@@ -9,6 +9,7 @@ import com.google.api.client.json.gson.GsonFactory;
 import lombok.RequiredArgsConstructor;
 import org.mentorship.reflectly.dto.AuthLoginResponseDto;
 import org.mentorship.reflectly.dto.UserProfileRecord;
+import org.mentorship.reflectly.exception.LocalAuthDisabledException;
 import org.mentorship.reflectly.model.UserEntity;
 import org.mentorship.reflectly.security.JwtService;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +38,14 @@ public class AuthService {
 
     @Value("${app.google.client-secret}")
     private String clientSecret;
+
+    /**
+     * Kill switch for username/password login and signup — disabled in production so the only
+     * way in is Google login (which carries Google's own bot/abuse resistance upstream), while
+     * staying enabled by default for local/dev testing. See app.auth.local-credentials-enabled.
+     */
+    @Value("${app.auth.local-credentials-enabled:true}")
+    private boolean localCredentialsEnabled;
 
     /**
      * Exchange a Google Auth Code for an ID Token, then verify and issue a backend JWT.
@@ -79,6 +88,7 @@ public class AuthService {
      * Authenticate a user with username and password credentials.
      */
     public AuthLoginResponseDto loginWithCredentials(String username, String password) {
+        requireLocalCredentialsEnabled();
         UserEntity user = userService.authenticateByCredentials(username, password);
         return buildAuthResponse(user);
     }
@@ -87,8 +97,16 @@ public class AuthService {
      * Register a new user with username, password, and optional display name.
      */
     public AuthLoginResponseDto signup(String username, String password, String fullName) {
+        requireLocalCredentialsEnabled();
         UserEntity user = userService.createUser(username, password, fullName);
         return buildAuthResponse(user);
+    }
+
+    private void requireLocalCredentialsEnabled() {
+        if (!localCredentialsEnabled) {
+            throw new LocalAuthDisabledException(
+                    "Đăng ký/đăng nhập bằng username và mật khẩu đã tắt. Vui lòng đăng nhập bằng Google.");
+        }
     }
 
     private AuthLoginResponseDto buildAuthResponse(UserEntity user) {

--- a/src/main/java/org/mentorship/reflectly/service/ConversationService.java
+++ b/src/main/java/org/mentorship/reflectly/service/ConversationService.java
@@ -8,11 +8,13 @@ import org.mentorship.reflectly.converter.ConversationConverter;
 import org.mentorship.reflectly.dto.ConversationMessageResponseDto;
 import org.mentorship.reflectly.dto.ConversationResponseDto;
 import org.mentorship.reflectly.exception.NotFoundException;
+import org.mentorship.reflectly.exception.QuotaExceededException;
 import org.mentorship.reflectly.exception.ValidationException;
 import org.mentorship.reflectly.model.*;
 import org.mentorship.reflectly.repository.ConversationMessageRepository;
 import org.mentorship.reflectly.repository.ConversationRepository;
 import org.mentorship.reflectly.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,9 +37,22 @@ public class ConversationService {
     private final ConversationSummaryService conversationSummaryService;
     private final ApplicationEventPublisher eventPublisher;
 
+    /**
+     * Alpha-phase hard cap on conversations per user, to bound Gemini API spend before this app
+     * has a real access/billing model. Env-tunable so it can be raised later with no code change.
+     */
+    @Value("${app.quota.max-conversations-per-user:5}")
+    private long maxConversationsPerUser;
+
     public ConversationResponseDto startConversation(Long userId) {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException("User not found"));
+
+        long existingCount = conversationRepository.countByUserId(userId);
+        if (existingCount >= maxConversationsPerUser) {
+            throw new QuotaExceededException(
+                    "Bạn đã dùng hết " + maxConversationsPerUser + " lượt trò chuyện thử nghiệm với Aura.");
+        }
 
         ConversationEntity conversation = new ConversationEntity(UUID.randomUUID().toString(), user);
         conversationRepository.save(conversation);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -34,6 +34,15 @@ app:
     client-secret: ${GOOGLE_CLIENT_SECRET}
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://gray-island-018b47d00.1.azurestaticapps.net}
+  auth:
+    # Production: Google login only. Override via LOCAL_AUTH_ENABLED=true if ever needed
+    # temporarily, but the default here is intentionally off.
+    local-credentials-enabled: ${LOCAL_AUTH_ENABLED:false}
+  quota:
+    max-conversations-per-user: ${MAX_CONVERSATIONS_PER_USER:5}
+  rate-limit:
+    auth-requests-per-minute: ${AUTH_RATE_LIMIT_PER_MINUTE:10}
+    conversation-requests-per-minute: ${CONVERSATION_RATE_LIMIT_PER_MINUTE:10}
 
 # Production logging configuration
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,13 @@ app:
     key: ${ENCRYPTION_KEY:}
   conversations:
     purge-after-extraction: ${PURGE_TRANSCRIPTS:false}
+  auth:
+    # Username/password login+signup — kept ON by default for local/dev testing.
+    local-credentials-enabled: ${LOCAL_AUTH_ENABLED:true}
+  quota:
+    # Alpha-phase hard cap on Coach conversations per user, to bound Gemini API spend.
+    # Raise via env var once ready for wider access — no code change needed.
+    max-conversations-per-user: ${MAX_CONVERSATIONS_PER_USER:5}
+  rate-limit:
+    auth-requests-per-minute: ${AUTH_RATE_LIMIT_PER_MINUTE:10}
+    conversation-requests-per-minute: ${CONVERSATION_RATE_LIMIT_PER_MINUTE:10}

--- a/src/test/java/org/mentorship/reflectly/service/AuthServiceTest.java
+++ b/src/test/java/org/mentorship/reflectly/service/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package org.mentorship.reflectly.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mentorship.reflectly.dto.AuthLoginResponseDto;
+import org.mentorship.reflectly.dto.UserProfileRecord;
+import org.mentorship.reflectly.exception.LocalAuthDisabledException;
+import org.mentorship.reflectly.model.UserEntity;
+import org.mentorship.reflectly.security.JwtService;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the local-credentials kill switch added to bound abuse before this app has a real
+ * access/billing model — see app.auth.local-credentials-enabled (off by default in prod).
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private GoogleIdTokenVerifier googleIdTokenVerifier;
+    @Mock
+    private UserService userService;
+    @Mock
+    private JwtService jwtService;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(googleIdTokenVerifier, userService, jwtService);
+    }
+
+    @Test
+    void loginWithCredentials_throwsWhenLocalAuthDisabled() {
+        ReflectionTestUtils.setField(authService, "localCredentialsEnabled", false);
+
+        assertThrows(LocalAuthDisabledException.class,
+                () -> authService.loginWithCredentials("someone", "password"));
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void signup_throwsWhenLocalAuthDisabled() {
+        ReflectionTestUtils.setField(authService, "localCredentialsEnabled", false);
+
+        assertThrows(LocalAuthDisabledException.class,
+                () -> authService.signup("someone", "password", "Full Name"));
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void signup_succeedsWhenLocalAuthEnabled() {
+        ReflectionTestUtils.setField(authService, "localCredentialsEnabled", true);
+
+        UserEntity user = new UserEntity();
+        user.setId(1L);
+        user.setEmail(null);
+        user.setUsername("someone");
+
+        when(userService.createUser("someone", "password", "Full Name")).thenReturn(user);
+        when(jwtService.generateToken("1", null)).thenReturn("jwt-token");
+        when(userService.toProfileRecord(user)).thenReturn(
+                new UserProfileRecord("1", null, "someone", "Full Name", "", false, List.of(), false));
+
+        AuthLoginResponseDto response = authService.signup("someone", "password", "Full Name");
+
+        assertThat(response.getToken()).isEqualTo("jwt-token");
+        assertThat(response.getUser().username()).isEqualTo("someone");
+    }
+}

--- a/src/test/java/org/mentorship/reflectly/service/ConversationServiceTest.java
+++ b/src/test/java/org/mentorship/reflectly/service/ConversationServiceTest.java
@@ -1,0 +1,90 @@
+package org.mentorship.reflectly.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mentorship.reflectly.ai.CoachAgentService;
+import org.mentorship.reflectly.ai.ConversationSummaryService;
+import org.mentorship.reflectly.converter.ConversationConverter;
+import org.mentorship.reflectly.dto.ConversationResponseDto;
+import org.mentorship.reflectly.exception.QuotaExceededException;
+import org.mentorship.reflectly.model.ConversationEntity;
+import org.mentorship.reflectly.model.UserEntity;
+import org.mentorship.reflectly.repository.ConversationMessageRepository;
+import org.mentorship.reflectly.repository.ConversationRepository;
+import org.mentorship.reflectly.repository.UserRepository;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the alpha-phase conversation quota added to bound Gemini API spend — see
+ * app.quota.max-conversations-per-user.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConversationServiceTest {
+
+    @Mock
+    private ConversationRepository conversationRepository;
+    @Mock
+    private ConversationMessageRepository conversationMessageRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ConversationConverter conversationConverter;
+    @Mock
+    private CoachAgentService coachAgentService;
+    @Mock
+    private ConversationSummaryService conversationSummaryService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private ConversationService conversationService;
+
+    @BeforeEach
+    void setUp() {
+        conversationService = new ConversationService(
+                conversationRepository, conversationMessageRepository, userRepository,
+                conversationConverter, coachAgentService, conversationSummaryService, eventPublisher);
+        ReflectionTestUtils.setField(conversationService, "maxConversationsPerUser", 5L);
+    }
+
+    @Test
+    void startConversation_throwsWhenAtQuota() {
+        Long userId = 42L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(new UserEntity()));
+        when(conversationRepository.countByUserId(userId)).thenReturn(5L);
+
+        assertThrows(QuotaExceededException.class, () -> conversationService.startConversation(userId));
+
+        verify(conversationRepository, never()).save(any());
+    }
+
+    @Test
+    void startConversation_succeedsUnderQuota() {
+        Long userId = 42L;
+        UserEntity user = new UserEntity();
+        user.setId(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(conversationRepository.countByUserId(userId)).thenReturn(4L);
+        when(conversationConverter.toResponseDto(any(ConversationEntity.class), eq(List.of())))
+                .thenReturn(ConversationResponseDto.builder().build());
+
+        ConversationResponseDto result = conversationService.startConversation(userId);
+
+        assertThat(result).isNotNull();
+        verify(conversationRepository).save(any(ConversationEntity.class));
+    }
+}


### PR DESCRIPTION
## Bối cảnh
App vừa deploy public tại mimose.io.vn, chưa có subscription/CAPTCHA, chỉ Google login đã bật sẵn. Trước đó **không có bất kỳ lớp bảo vệ nào**: signup mở tự do, zero rate-limit, zero quota — rủi ro bị script spam đốt hết `GEMINI_API_KEY`.

## Thay đổi
- **Google-only ở prod**: `AuthService.loginWithCredentials`/`signup` throw 403 nếu `app.auth.local-credentials-enabled=false` (mặc định `true` ở dev/test để giữ test chạy được, `false` ở `application-prod.yml`). Override qua `LOCAL_AUTH_ENABLED`.
- **Rate limit (Bucket4j, in-memory, không cần Redis)**: `RateLimitFilter` mới — 10 req/phút theo IP trên `/api/auth/**`, 10 req/phút theo user trên `POST /api/conversations/**`.
- **Quota cứng 5 conversation/user** trong giai đoạn alpha (`ConversationService.startConversation`), trả 429 khi vượt.
- **Log token usage** (total/prompt/candidates) ở mức INFO mỗi lần gọi Gemini trong `CoachAgentService`, `ConversationSummaryService`, `MemoryExtractionService` — để xem xu hướng burn token qua Azure Log Stream.
- 2 exception mới (`LocalAuthDisabledException` 403, `QuotaExceededException` 429) + wiring vào `GlobalExceptionHandler`.
- Test mới: `AuthServiceTest`, `ConversationServiceTest`.

## Env vars (đều có default, không bắt buộc phải set)
| Env var | Default (prod) | Ý nghĩa |
|---|---|---|
| `LOCAL_AUTH_ENABLED` | `false` | bật lại username/password login nếu cần |
| `MAX_CONVERSATIONS_PER_USER` | `5` | nâng quota khi sẵn sàng mở rộng |
| `AUTH_RATE_LIMIT_PER_MINUTE` | `10` | rate limit cho `/api/auth/**` |
| `CONVERSATION_RATE_LIMIT_PER_MINUTE` | `10` | rate limit cho Coach chat |

**Cần làm thủ công sau khi merge**: cập nhật secret `APP_CORS_ALLOWED_ORIGINS` (GitHub Actions repo secret, đang được push vào Azure App Service settings ở `.github/workflows/main_reflectlybe.yml`) để gồm `https://mimose.io.vn` — hiện vẫn là domain Azure cũ.

## Verification
- `mvn test`: toàn bộ pass, gồm 5 test mới (`AuthServiceTest` x3, `ConversationServiceTest` x2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)